### PR TITLE
✨ Feat: 소비루틴 가져오기 페이지 통신 완료

### DIFF
--- a/src/components/home/routine/routineCard.tsx
+++ b/src/components/home/routine/routineCard.tsx
@@ -3,7 +3,6 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import rightArrow from '../../../assets/images/home/rightArrow.png';
 import dateDot from '../../../assets/images/home/routine/dateDot.png';
-import { isToday } from '../../../utils/home/todayCheck';
 import type { UserRoutineDetail } from '../../../types/home/routine';
 
 interface Props {
@@ -27,19 +26,15 @@ export default function RoutineCard({ item }: Props) {
   const navigate = useNavigate();
 
   const handleClick = useCallback(() => {
-    navigate(`/routine/${item.id}`);
-  }, [item.id, navigate]);
+    navigate(`/routine/${item.routineId}`);
+  }, [item.routineId, navigate]);
 
-  const isNew = isToday(item.startDate);
+  const isNew = item.new;
 
   return (
     <div className={S.Card} onClick={handleClick}>
       <div className={S.Left}>
-        <img
-          src={item.thumbnail}
-          alt="routine thumbnail"
-          className={S.Thumbnail}
-        />
+        <img src={item.routineImgUrl} alt="thumbnail" className={S.Thumbnail} />
       </div>
 
       <div className={S.Content(isNew)}>
@@ -48,19 +43,21 @@ export default function RoutineCard({ item }: Props) {
             {isNew ? (
               <div className={S.NewBadge}>NEW</div>
             ) : (
-              <div className={S.Date}>{formatDateWithDots(item.startDate)}</div>
+              <div className={S.Date}>
+                {formatDateWithDots(item.createDate)}
+              </div>
             )}
           </div>
 
           <div className={S.Title}>
-            {item.title}
+            {item.routineName}
             <img src={rightArrow} alt="navigate" className={S.RightArrowImg} />
           </div>
 
           <div className={S.HashtagList}>
-            {item.hashtags.map((tag) => (
-              <span key={tag} className={S.Hashtag}>
-                {tag}
+            {item.hashtags.map((hashtag) => (
+              <span key={hashtag} className={S.Hashtag}>
+                {hashtag}
               </span>
             ))}
           </div>
@@ -68,11 +65,11 @@ export default function RoutineCard({ item }: Props) {
 
         <div className={S.Author}>
           <img
-            src={item.authorProfileImg}
+            src={item.profileImgUrl}
             alt="profile"
             className={S.ProfileImg}
           />
-          <div className={S.AuthorName}>{item.author}</div>
+          <div className={S.AuthorName}>{item.nickname}</div>
         </div>
       </div>
     </div>

--- a/src/hooks/home/routine/useDebounce.ts
+++ b/src/hooks/home/routine/useDebounce.ts
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/hooks/home/routine/useInfiniteScroll.ts
+++ b/src/hooks/home/routine/useInfiniteScroll.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+
+export function useInfiniteScroll(callback: () => void, canFetch: boolean) {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!bottomRef.current || !canFetch) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          callback();
+        }
+      },
+      { threshold: 1.0 },
+    );
+
+    observer.observe(bottomRef.current);
+
+    return () => observer.disconnect();
+  }, [callback, canFetch]);
+
+  return bottomRef;
+}

--- a/src/hooks/home/routine/useRoutine.ts
+++ b/src/hooks/home/routine/useRoutine.ts
@@ -1,0 +1,23 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { API } from '../../../apis/axios';
+import type { RoutineResponse } from '../../../types/home/routine';
+
+export function useRoutine() {
+  return useInfiniteQuery<RoutineResponse, Error>({
+    queryKey: ['routineData'],
+    queryFn: async ({ pageParam = null }) => {
+      const url = pageParam
+        ? `/api/house-holds/routines/list?cursorId=${pageParam}`
+        : '/api/house-holds/routines/list';
+
+      const res = await API.get<RoutineResponse>(url);
+      if (!res.data.isSuccess) {
+        throw new Error(res.data.message || '조회 실패');
+      }
+      return res.data;
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.result.hasNext ? lastPage.result.nextCursorId : undefined,
+    initialPageParam: null,
+  });
+}

--- a/src/hooks/home/routine/useRoutineData.ts
+++ b/src/hooks/home/routine/useRoutineData.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { useRoutine } from './useRoutine';
+import { useRoutineSearch } from './useSearchRoutine';
+import { useDebounce } from './useDebounce';
+
+export function useRoutineData(input: string) {
+  const debouncedInput = useDebounce(input, 500);
+  const isSearching = debouncedInput.trim().length > 0;
+
+  const routineData = useRoutine();
+  const searchData = useRoutineSearch(debouncedInput);
+
+  const merged = useMemo(() => {
+    const data = isSearching ? searchData.data : routineData.data;
+    const fetchNextPage = isSearching
+      ? searchData.fetchNextPage
+      : routineData.fetchNextPage;
+    const hasNextPage = isSearching
+      ? searchData.hasNextPage
+      : routineData.hasNextPage;
+    const isFetchingNextPage = isSearching
+      ? searchData.isFetchingNextPage
+      : routineData.isFetchingNextPage;
+    const isLoading = isSearching
+      ? searchData.isLoading
+      : routineData.isLoading;
+    const error = isSearching ? searchData.error : routineData.error;
+
+    return {
+      data,
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      isLoading,
+      error,
+      isSearching,
+      debouncedInput,
+    };
+  }, [isSearching, routineData, searchData]);
+
+  return merged;
+}

--- a/src/hooks/home/routine/useSearchRoutine.ts
+++ b/src/hooks/home/routine/useSearchRoutine.ts
@@ -1,0 +1,25 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { API } from '../../../apis/axios';
+import type { RoutineSearchResponse } from '../../../types/home/routine';
+
+export function useRoutineSearch(keyword: string) {
+  return useInfiniteQuery<RoutineSearchResponse, Error>({
+    queryKey: ['routineSearch', keyword],
+    queryFn: async ({ pageParam = null }) => {
+      const url =
+        pageParam !== null
+          ? `/api/house-holds/routines/list/search?keyword=${keyword}&cursorId=${pageParam}`
+          : `/api/house-holds/routines/list/search?keyword=${keyword}`;
+
+      const res = await API.get<RoutineSearchResponse>(url);
+      if (!res.data.isSuccess) {
+        throw new Error(res.data.message || '검색 실패');
+      }
+      return res.data;
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.result.hasNext ? lastPage.result.nextCursorId : undefined,
+    enabled: !!keyword,
+    initialPageParam: null,
+  });
+}

--- a/src/mocks/home/mockRoutineData.ts
+++ b/src/mocks/home/mockRoutineData.ts
@@ -1,5 +1,4 @@
 import type { UserRoutine } from '../../types/home/routine';
-import type { UserRoutineDetail } from '../../types/home/routine';
 import type { FullRoutineDetail } from '../../types/home/routine';
 import routine_t from '../../assets/images/home/routine_t.png';
 import profile_t from '../../assets/images/home/profile_t.png';
@@ -40,64 +39,6 @@ export const mockRoutineData: UserRoutine[] = [
     icon: routine_t,
     startDate: '2025-07-01',
     views: 50,
-  },
-];
-
-export const mockRoutineDetailData: UserRoutineDetail[] = [
-  {
-    id: 1,
-    title: '50만원으로 한 달 살기 루틴',
-    icon: routine_t,
-    startDate: '2025-07-21',
-    views: 300,
-    hashtags: ['#식비절약', '#생활비'],
-    thumbnail: thumbnail,
-    author: '라인',
-    authorProfileImg: profile_t,
-  },
-  {
-    id: 2,
-    title: '배달 끊고 집밥 먹기 예산',
-    icon: routine_t,
-    startDate: '2025-07-21',
-    views: 200,
-    hashtags: ['#식비절약', '#배달끊기'],
-    thumbnail: thumbnail,
-    author: '이즈',
-    authorProfileImg: profile_t,
-  },
-  {
-    id: 3,
-    title: '커피값을 아끼자',
-    icon: routine_t,
-    startDate: '2025-07-07',
-    views: 100,
-    hashtags: ['#커피절약'],
-    thumbnail: thumbnail,
-    authorProfileImg: profile_t,
-    author: '오리',
-  },
-  {
-    id: 4,
-    title: '쇼핑은 10만원만',
-    icon: routine_t,
-    startDate: '2025-07-06',
-    views: 10,
-    hashtags: ['#쇼핑절제', '#지출관리'],
-    thumbnail: thumbnail,
-    authorProfileImg: profile_t,
-    author: '앨빈',
-  },
-  {
-    id: 5,
-    title: '줄줄 새는 고정비 확인하기',
-    icon: routine_t,
-    startDate: '2025-07-01',
-    views: 50,
-    hashtags: ['#고정비정리', '#자동이체점검'],
-    thumbnail: thumbnail,
-    authorProfileImg: profile_t,
-    author: '잔디',
   },
 ];
 

--- a/src/pages/home/routine.tsx
+++ b/src/pages/home/routine.tsx
@@ -4,18 +4,47 @@ import searchIcon from '../../assets/images/home/routine/search.png';
 import noResult from '../../assets/images/home/routine/noResult.png';
 import Header from '../../components/header/header';
 import RoutineCard from '../../components/home/routine/routineCard';
-import { mockRoutineDetailData } from '../../mocks/home/mockRoutineData';
+import { useRoutineData } from '../../hooks/home/routine/useRoutineData';
+import { useInfiniteScroll } from '../../hooks/home/routine/useInfiniteScroll';
+import type { UserRoutineDetail } from '../../types/home/routine';
 
 function Routine() {
-  const [search, setSearch] = useState('');
+  const [inputValue, setInputValue] = useState('');
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    error,
+    isSearching,
+  } = useRoutineData(inputValue);
 
-  const sortedData = [...mockRoutineDetailData].sort(
-    (a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime(),
+  const routines: UserRoutineDetail[] = data
+    ? data.pages.flatMap((page) => page.result.routineList)
+    : [];
+
+  const bottomRef = useInfiniteScroll(
+    fetchNextPage,
+    hasNextPage && !isFetchingNextPage,
   );
 
-  const filteredData = sortedData.filter((item) =>
-    item.title.toLowerCase().includes(search.toLowerCase()),
-  );
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      setInputValue(inputValue.trim());
+    }
+  };
+
+  const handleSearchClick = () => {
+    setInputValue(inputValue.trim());
+  };
+
+  if (isLoading) return <div></div>;
+  if (error) return <div></div>;
 
   return (
     <div className={`pageContainer ${S.Container}`}>
@@ -24,22 +53,33 @@ function Routine() {
         <input
           type="text"
           placeholder="검색어를 입력해 주세요."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          value={inputValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
           className={S.SearchInput}
         />
-        <img src={searchIcon} alt="검색" className={S.SearchIcon} />
+        <img
+          src={searchIcon}
+          alt="검색"
+          className={S.SearchIcon}
+          onClick={handleSearchClick}
+          style={{ cursor: 'pointer' }}
+        />
       </div>
-      {filteredData.length === 0 ? (
+
+      {isSearching && routines.length === 0 ? (
         <div className={S.NoResultWrapper}>
           <img src={noResult} alt="검색 결과 없음" className={S.NoResultImg} />
         </div>
       ) : (
-        <div className={S.List}>
-          {filteredData.map((item) => (
-            <RoutineCard key={item.id} item={item} />
-          ))}
-        </div>
+        <>
+          <div className={S.List}>
+            {routines.map((item) => (
+              <RoutineCard key={item.routineId} item={item} />
+            ))}
+          </div>
+          <div ref={bottomRef} />
+        </>
       )}
     </div>
   );

--- a/src/types/home/routine.ts
+++ b/src/types/home/routine.ts
@@ -3,14 +3,47 @@ export interface UserRoutine {
   title: string;
   icon: string;
   startDate: string;
-  views: number;
 }
 
-export interface UserRoutineDetail extends UserRoutine {
+export interface UserRoutineDetail {
+  routineId: number;
+  createDate: string;
+  routineName: string;
+  nickname: string;
+  routineImgUrl: string;
+  profileImgUrl: string;
   hashtags: string[];
-  thumbnail: string;
-  author: string;
-  authorProfileImg: string;
+  new: boolean;
+}
+
+export interface RoutineResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    routineList: UserRoutineDetail[];
+    routineListSize: number;
+    isFirst: boolean;
+    isLast: boolean;
+    hasNext: boolean;
+    nextCursorId: number | null;
+  };
+}
+
+export interface RoutineSearchResult {
+  routineList: UserRoutineDetail[];
+  routineListSize: number;
+  isFirst: boolean;
+  isLast: boolean;
+  hasNext: boolean;
+  nextCursorId: number | null;
+}
+
+export interface RoutineSearchResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: RoutineSearchResult;
 }
 
 export type RoutineBudget = {

--- a/src/types/home/routine.ts
+++ b/src/types/home/routine.ts
@@ -3,6 +3,7 @@ export interface UserRoutine {
   title: string;
   icon: string;
   startDate: string;
+  views: number;
 }
 
 export interface UserRoutineDetail {
@@ -46,13 +47,20 @@ export interface RoutineSearchResponse {
   result: RoutineSearchResult;
 }
 
+export interface RoutineDetail extends UserRoutine {
+  thumbnail: string;
+  author: string;
+  authorProfileImg: string;
+}
+
 export type RoutineBudget = {
   label: string;
   amount: number;
 };
 
-export interface FullRoutineDetail extends UserRoutineDetail {
+export interface FullRoutineDetail extends RoutineDetail {
   totalBudget: number;
   budgetList: RoutineBudget[];
   isReflected: boolean;
+  hashtags: string[];
 }


### PR DESCRIPTION
## 🚀 관련 이슈


- close #58  

## 🔑 작업 내용

소비루틴 가져오기 페이지 통신(전체 조회 및 검색)

## 📷 스크린샷

<img width="2560" height="1517" alt="스크린샷(13)" src="https://github.com/user-attachments/assets/d718c4c1-6b6d-4105-8172-0909dfa88078" />
<img width="2560" height="1531" alt="스크린샷(15)" src="https://github.com/user-attachments/assets/81968e49-3b7c-4015-8627-e5d664e8683e" />
<img width="2560" height="1528" alt="스크린샷(16)" src="https://github.com/user-attachments/assets/e1cd6567-9dcf-486f-bb18-fec7f65bbf54" />
<img width="2560" height="1523" alt="스크린샷(17)" src="https://github.com/user-attachments/assets/bb7a8b4c-762f-4921-9d70-ea63b5ff49a7" />



## 🌐 공유 사항 to 리뷰어
1. 소비루틴 타입 파일 및 목데이터 파일은 소비루틴_상세, 홈 소비루틴 리스트 api 연결 후 정리하겠습니다.
2. 썸네일은 이미지 경로가 https:// 까지만 있어서 저렇게 나옵니다.

## 🚨 이슈 사항


