### PR TITLE
🎨 Design: auth, header, footer 스타일링 수정

### DIFF
--- a/src/components/auth/mypage/mypage/menu/item-menu.tsx
+++ b/src/components/auth/mypage/mypage/menu/item-menu.tsx
@@ -2,15 +2,35 @@ import * as M from '../../../../../styles/auth/mypage/mypage.style';
 import RightArrow from '../../../../../assets/images/auth/mypage/rightArrow.png';
 import type { MenuItem } from '../../../../../types/auth/mypage/mypage';
 import { useNavigate } from 'react-router-dom';
+import { useDeleteMutation } from '../../../../../hooks/auth/mypage/useDeleteMutation';
 
-const ItemMenu = ({ item }: { item: MenuItem }) => {
+const ItemMenu = ({ item, userId }: { item: MenuItem; userId: number }) => {
   const navigate = useNavigate();
+  // console.log('userId', userId);
 
-  const handleClick = () => {
+  const handleClick = async () => {
     if (item.name === '로그아웃') {
       localStorage.clear();
       alert('로그아웃이 완료되었습니다.');
       navigate('/login');
+    } else if (item.name === '회원 탈퇴') {
+      const confirmed = window.confirm('정말로 회원탈퇴를 진행하시겠습니까?');
+      if (!confirmed) return;
+
+      try {
+        const res = await useDeleteMutation({ userId });
+
+        if (res.isSuccess) {
+          localStorage.clear();
+          alert('회원탈퇴가 완료되었습니다.');
+          navigate('/');
+        } else {
+          alert(res.message || '회원탈퇴에 실패했습니다.');
+        }
+      } catch (error) {
+        console.error(error);
+        alert('회원탈퇴 중 오류가 발생했습니다.');
+      }
     }
   };
 

--- a/src/components/auth/mypage/mypage/menu/list-menu.tsx
+++ b/src/components/auth/mypage/mypage/menu/list-menu.tsx
@@ -2,11 +2,11 @@ import * as M from '../../../../../styles/auth/mypage/mypage.style';
 import ItemMenu from './item-menu';
 import type { MenuItem } from '../../../../../types/auth/mypage/mypage';
 
-const ListMenu = ({ list }: { list: MenuItem[] }) => {
+const ListMenu = ({ list, userId }: { list: MenuItem[]; userId: number }) => {
   return (
     <div className={M.ListMenuContainer}>
       {list.map((item) => (
-        <ItemMenu key={item.id} item={item} />
+        <ItemMenu key={item.id} item={item} userId={userId} />
       ))}
     </div>
   );

--- a/src/components/auth/mypage/mypage/section/item-section.tsx
+++ b/src/components/auth/mypage/mypage/section/item-section.tsx
@@ -2,11 +2,17 @@ import * as M from '../../../../../styles/auth/mypage/mypage.style';
 import ListMenu from '../menu/list-menu';
 import type { MenuSection } from '../../../../../types/auth/mypage/mypage';
 
-const ItemSection = ({ item }: { item: MenuSection }) => {
+const ItemSection = ({
+  item,
+  userId,
+}: {
+  item: MenuSection;
+  userId: number;
+}) => {
   return (
     <div className={M.ItemSectionContainer}>
       <p className={M.ItemSectionP}>{item.title}</p>
-      <ListMenu list={item.list} />
+      <ListMenu list={item.list} userId={userId} />
     </div>
   );
 };

--- a/src/components/auth/mypage/mypage/section/list-section.tsx
+++ b/src/components/auth/mypage/mypage/section/list-section.tsx
@@ -2,11 +2,11 @@ import * as M from '../../../../../styles/auth/mypage/mypage.style';
 import SectionData from '../../../../../mocks/auth/mypage/mypage/sectionData';
 import ItemSection from './item-section';
 
-const ListSection = () => {
+const ListSection = ({ userId }: { userId: number }) => {
   return (
     <div className={M.ListSectionContainer}>
       {SectionData.map((item) => (
-        <ItemSection key={item.id} item={item} />
+        <ItemSection key={item.id} item={item} userId={userId} />
       ))}
     </div>
   );

--- a/src/components/auth/signup/agree/agree.tsx
+++ b/src/components/auth/signup/agree/agree.tsx
@@ -30,7 +30,7 @@ const Agree = ({ onNext, agreeList, setAgreeList }: AgreeProps) => {
   };
 
   return (
-    <div className={S.AgreeContainer}>
+    <div className={`${S.AgreeContainer} pt-[8.4rem]`}>
       <Header />
 
       <p className={S.AgreeP}>

--- a/src/components/auth/signup/setting/setting.tsx
+++ b/src/components/auth/signup/setting/setting.tsx
@@ -9,7 +9,7 @@ interface SettingProps {
 
 const Setting = ({ onNext, onBack }: SettingProps) => {
   return (
-    <div className={S.AgreeContainer}>
+    <div className={`${S.AgreeContainer} pt-[8.4rem]`}>
       <Header onBack={onBack} />
 
       <p className={S.AgreeP}>

--- a/src/components/auth/test/onboarding/onboarding.tsx
+++ b/src/components/auth/test/onboarding/onboarding.tsx
@@ -50,7 +50,7 @@ const Onboarding = ({
 
   return (
     <div className={S.AgreeContainer}>
-      <div className={T.OnboardingTopContainer}>
+      <div className={`${T.OnboardingTopContainer} !px-[2.4rem]`}>
         <p className={T.OnboardingP}>안녕하세요!</p>
         <p
           className={`${T.OnboardingP} !text-[2rem] !text-[var(--color-G1)] !leading-[2.8rem]`}

--- a/src/components/auth/test/qna/qnaForm.tsx
+++ b/src/components/auth/test/qna/qnaForm.tsx
@@ -36,7 +36,7 @@ const QnaForm = ({ pageIndex, setPageIndex, onNext }: QnaFormProps) => {
   const isPageAnswered = currentPage.qnaList.every((qna) => answers[qna.qnaId]);
 
   return (
-    <div className={`${T.ListOnboardingContainer} !px-0 !gap-0`}>
+    <div className={`${T.ListOnboardingContainer} !px-0 !gap-0 !mt-[8.4rem]`}>
       <p className={`${T.MbtiP} !mt-[1rem] !mb-[3.4rem]`}>
         {currentPage.title}
       </p>

--- a/src/components/auth/test/qna/qnaForm.tsx
+++ b/src/components/auth/test/qna/qnaForm.tsx
@@ -36,7 +36,7 @@ const QnaForm = ({ pageIndex, setPageIndex, onNext }: QnaFormProps) => {
   const isPageAnswered = currentPage.qnaList.every((qna) => answers[qna.qnaId]);
 
   return (
-    <div className={`${T.ListOnboardingContainer} !gap-0`}>
+    <div className={`${T.ListOnboardingContainer} !px-0 !gap-0`}>
       <p className={`${T.MbtiP} !mt-[1rem] !mb-[3.4rem]`}>
         {currentPage.title}
       </p>

--- a/src/components/auth/test/result/result.tsx
+++ b/src/components/auth/test/result/result.tsx
@@ -31,7 +31,7 @@ const Result = ({ onBack }: ResultProps) => {
 
   return (
     <div
-      className={S.AgreeContainer}
+      className={`${S.AgreeContainer} !pt-[8.4rem]`}
       style={{ background: matchedResult?.background }}
     >
       <Header onBack={onBack} title={`${nickname}님의 소비 MBTI는?`} />

--- a/src/components/auth/test/result/result.tsx
+++ b/src/components/auth/test/result/result.tsx
@@ -34,7 +34,11 @@ const Result = ({ onBack }: ResultProps) => {
       className={`${S.AgreeContainer} !pt-[8.4rem]`}
       style={{ background: matchedResult?.background }}
     >
-      <Header onBack={onBack} title={`${nickname}님의 소비 MBTI는?`} />
+      <Header
+        onBack={onBack}
+        bgColor="none"
+        title={`${nickname}님의 소비 MBTI는?`}
+      />
       <ResultForm data={matchedResult} />
 
       <div className={`${S.BottomContainer} !mt-[8.1rem]`}>

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -5,9 +5,10 @@ import { useNavigate } from 'react-router-dom';
 interface HeaderProps {
   onBack?: () => void;
   title?: string;
+  bgColor?: string;
 }
 
-const Header = ({ onBack, title }: HeaderProps) => {
+const Header = ({ onBack, title, bgColor = 'bg-white' }: HeaderProps) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -16,7 +17,7 @@ const Header = ({ onBack, title }: HeaderProps) => {
   };
 
   return (
-    <div className={H.HeaderContainer}>
+    <div className={`${H.HeaderContainer} ${bgColor}`}>
       <img
         className={H.LeftArrowImg}
         src={LeftArrow}

--- a/src/hooks/auth/mypage/useDeleteMutation.tsx
+++ b/src/hooks/auth/mypage/useDeleteMutation.tsx
@@ -1,0 +1,14 @@
+import { API } from '../../../apis/axios';
+import type {
+  DeleteRequest,
+  DeleteResponse,
+} from '../../../types/auth/mypage/mypage';
+
+export const useDeleteMutation = async (
+  payload: DeleteRequest,
+): Promise<DeleteResponse> => {
+  const { data } = await API.post<DeleteResponse>('/api/user/delete', null, {
+    params: { userId: payload.userId },
+  });
+  return data;
+};

--- a/src/pages/auth/mypage/myfeed.tsx
+++ b/src/pages/auth/mypage/myfeed.tsx
@@ -24,7 +24,9 @@ const Myfeed = () => {
   }, [inView, hasNextPage, fetchNextPage]);
 
   return (
-    <div className={`${S.AgreeContainer} !pb-[1.2rem]`}>
+    <div
+      className={`${S.AgreeContainer} !pt-[8.4rem] !h-[calc(100vh-13rem)] !mb-[13rem] !overflow-y-auto`}
+    >
       <Header title="MY 피드" />
       <ListGrid selectedId={selectedId} setSelectedId={setSelectedId} />
 

--- a/src/pages/auth/mypage/mypage.tsx
+++ b/src/pages/auth/mypage/mypage.tsx
@@ -11,7 +11,7 @@ const Mypage = () => {
 
   return (
     <div
-      className={`${S.AgreeContainer} !pb-[11.6rem] !bg-[var(--color-B2)] !px-0`}
+      className={`${S.AgreeContainer} !bg-[var(--color-B2)] !px-0 !h-[calc(100vh-13rem)] !mb-[13rem] !overflow-y-auto !pb-[11.6rem]`}
     >
       <Profile data={data} />
 

--- a/src/pages/auth/mypage/mypage.tsx
+++ b/src/pages/auth/mypage/mypage.tsx
@@ -19,7 +19,7 @@ const Mypage = () => {
 
       <ListButton />
 
-      <ListSection />
+      <ListSection userId={data?.result?.userId} />
     </div>
   );
 };

--- a/src/styles/auth/login/login.style.ts
+++ b/src/styles/auth/login/login.style.ts
@@ -1,5 +1,6 @@
 // login.tsx
-export const LoginContainer = 'bg-[var(--color-B1)] flex flex-col items-center';
+export const LoginContainer =
+  'bg-[var(--color-B1)] flex flex-col items-center px-[2.4rem]';
 
 export const LogoContainer = 'flex items-end mt-[12.3rem]';
 
@@ -8,9 +9,9 @@ export const LogoImg = 'w-[6rem] h-[6rem]';
 export const LogoP = 'text-[3rem] font-hakgyoB text-[var(--color-mainColor1)]';
 
 // loginForm.tsx
-export const LoginFormContainer = 'w-[37.7rem] flex flex-col gap-[1.6rem]';
+export const LoginFormContainer = 'w-full flex flex-col gap-[1.6rem]';
 
-export const InputContainer = 'flex flex-col gap-[0.6rem] mt-[5rem]';
+export const InputContainer = 'w-full flex flex-col gap-[0.6rem] mt-[5rem]';
 
 export const LoginButton =
   'w-full h-[4.5rem] rounded-[0.5rem] cursor-pointer bg-[var(--color-G1)] text-[var(--color-white)] text-[1.5rem] font-medium';
@@ -25,7 +26,8 @@ export const IconImg =
   'absolute right-[1.5rem] top-1/2 translate-y-[-50%] w-[1.8rem] h-[1.8rem] cursor-pointer';
 
 // list-menu.tsx
-export const ListMenuContainer = 'flex gap-[2.4rem] mt-[1.6rem] mb-[3rem]';
+export const ListMenuContainer =
+  'w-full items-center justify-center flex gap-[2.4rem] mt-[1.6rem] mb-[3rem]';
 
 // item-menu.tsx
 export const ItemP = (clickable: boolean) =>
@@ -33,7 +35,7 @@ export const ItemP = (clickable: boolean) =>
 
 // kakao.tsx
 export const KakaoButton =
-  'w-[37.7rem] h-[4.5rem] cursor-pointer bg-[var(--color-yellow)] px-[1rem] rounded-[0.5rem]';
+  'w-full h-[4.5rem] cursor-pointer bg-[var(--color-yellow)] px-[1rem] rounded-[0.5rem]';
 
 export const InnerContainer =
   'flex items-center justify-center gap-[0.8rem] text-[1.5rem] font-medium text-[rgba(0,0,0,0.85)]';

--- a/src/styles/auth/mypage/myfeed.style.ts
+++ b/src/styles/auth/mypage/myfeed.style.ts
@@ -1,19 +1,21 @@
 // list-grid.tsx
 export const ListGridContainer =
-  'w-[37.7rem] mt-[1rem] mb-[1.2rem] flex items-center justify-end';
+  'w-full mt-[1rem] mb-[1.2rem] px-[2.4rem] flex items-center justify-end';
 
 // item-grid.tsx
 export const ItemGridImg = 'w-[1.8rem] h-[1.8rem] cursor-pointer';
 
 // list-grid4.tsx
-export const ListGrid4Container = 'w-[37.7rem] grid grid-cols-3 gap-[0.4rem]';
+export const ListGrid4Container =
+  'w-full grid grid-cols-3 gap-[0.4rem] px-[2.4rem] pb-[1rem]';
 
 // item-grid4.tsx
 export const ItemGrid4Div =
   'w-full h-[11.8rem] rounded-[0.5rem] bg-[var(--color-G1)] cursor-pointer';
 
 // list-grid2.tsx
-export const ListGrid2Container = 'w-[37.7rem] flex flex-col gap-[2rem]';
+export const ListGrid2Container =
+  'w-full flex flex-col gap-[2rem] px-[2.4rem] pb-[1rem]';
 
 // item-grid2.tsx
 export const ItemGrid2Contaienr =

--- a/src/styles/auth/signup/signup.style.ts
+++ b/src/styles/auth/signup/signup.style.ts
@@ -1,17 +1,16 @@
 import type { InputButtonProps } from '../../../types/auth/signup/setting';
 
 // signup.tsx
-export const SignupContainer = 'flex';
+export const SignupContainer = 'flex w-full';
 
 // agree.tsx
-export const AgreeContainer =
-  'flex flex-col items-center w-full h-full px-[2.4rem]';
+export const AgreeContainer = 'flex flex-col items-center w-full h-full ';
 
 export const AgreeP =
-  'w-[37.7rem] text-[2.4rem] font-bold text-[var(--color-G1)] leading-[3.4rem] mt-[2.8rem]';
+  'w-full text-[2.4rem] font-bold text-[var(--color-G1)] leading-[3.4rem] mt-[2.8rem]  px-[2.4rem]';
 
 export const BottomContainer =
-  'w-[37.7rem] mt-[18.4rem] flex flex-col items-center gap-[1rem]';
+  'w-full mt-[18.4rem] flex flex-col items-center gap-[1rem]  px-[2.4rem]';
 
 export const NextButton = (active: boolean) =>
   `w-full h-[5rem] rounded-[1rem] text-[1.8rem] font-medium text-[var(--color-white)] ${
@@ -25,7 +24,7 @@ export const BottomP =
 
 // agreeForm.tsx
 export const AgreeFormContainer =
-  'w-[37.7rem] flex flex-col gap-[2.2rem] mt-[6rem]';
+  'w-full  px-[2.4rem] flex flex-col gap-[2.2rem] mt-[6rem]';
 
 export const AgreeItemContainer = 'flex items-center gap-[1rem] cursor-pointer';
 
@@ -39,7 +38,8 @@ export const AgreeBar = 'w-full h-[0.1rem] bg-[var(--color-G7)]';
 export const ListContainer = 'flex flex-col gap-[1.8rem]';
 
 // settingForm.tsx
-export const Container = 'w-[37.7rem] mt-[2.6rem] flex flex-col gap-[3.2rem]';
+export const Container =
+  'w-full px-[2.4rem] mt-[2.6rem] flex flex-col gap-[3.2rem]';
 
 export const InputWrapper = 'w-full flex flex-col gap-[0.6rem] relative';
 
@@ -84,7 +84,7 @@ export const ToggleIcon = ({ hasDelete }: InputButtonProps): string =>
 
 // profileForm.tsx
 export const ProfileFormContainer =
-  'w-[37.7rem] flex flex-col items-center gap-[2.5rem] mt-[6rem]';
+  'w-full px-[2.4rem] flex flex-col items-center gap-[2.5rem] mt-[6rem]';
 
 // profileImage.tsx
 export const Img =

--- a/src/styles/auth/signup/signup.style.ts
+++ b/src/styles/auth/signup/signup.style.ts
@@ -58,7 +58,7 @@ export const Input = ({ hasError, hasButton }: InputButtonProps): string =>
   `;
 
 export const Button = ({ hasError }: InputButtonProps): string => `
-  w-[8.3rem] h-[4.5rem] rounded-[0.5rem] text-[1.4rem] font-medium ${
+  w-[8.3rem] h-[4.5rem] rounded-[0.5rem] text-[1.4rem] font-medium whitespace-pre-line ${
     hasError
       ? 'bg-[var(--color-G7)] text-[var(--color-G5)] cursor-not-allowed'
       : 'bg-[var(--color-mainColor1)] text-[var(--color-white)] cursor-pointer'

--- a/src/styles/auth/test/test.style.ts
+++ b/src/styles/auth/test/test.style.ts
@@ -1,15 +1,17 @@
 // onboarding.tsx
 export const OnboardingTopContainer =
-  'flex flex-col gap-[0.4rem] mb-[3.6rem] mt-[8.4rem] w-[37.7rem]';
+  'flex flex-col gap-[0.4rem] mb-[3.6rem] mt-[8.4rem] w-full';
 
-export const OnboardingP = 'text-[1.6rem] font-medium text-[var(--color-G4)]';
+export const OnboardingP =
+  'w-full text-[1.6rem] font-medium text-[var(--color-G4)]';
 
-export const ListOnboardingContainer = 'w-[37.7rem] flex flex-col gap-[3.2rem]';
+export const ListOnboardingContainer =
+  'w-full flex flex-col gap-[3.2rem] px-[2.4rem]';
 
 export const ItemOnboardingContainer = 'w-full flex flex-col gap-[0.6rem]';
 
 export const ItemOnboardingP =
-  '	text-[1.5rem] font-medium text-[var(--color-G1)]';
+  'w-full	text-[1.5rem] font-medium text-[var(--color-G1)]';
 
 export const ListSelectContainer = 'flex gap-[0.7rem] mb-[1.1rem] flex-wrap';
 
@@ -22,7 +24,7 @@ export const ItemSelectContainer = (selected: boolean) =>
 
 // mbti.tsx
 export const MbtiP =
-  'text-[2rem] font-bold text-[var(--color-G1)] mt-[9.3rem] mb-[6.2rem]';
+  'text-[2rem] font-bold text-[var(--color-G1)] mt-[9.3rem] mb-[6.2rem] px-[2.4rem]';
 
 export const MbtiImg = 'w-[34.658rem] h-[19.1rem]';
 
@@ -31,7 +33,7 @@ export const MbtiSkipP =
 
 // qna.tsx
 export const NavbarContainer =
-  'flex justify-center absolute top-[5.1rem] gap-[0.5rem]';
+  'w-full flex justify-center absolute top-[5.1rem] gap-[0.5rem]';
 
 export const NavbarDot = (active: boolean) =>
   `${active ? 'w-[1.1rem] rounded-[0.3rem]' : 'w-[0.6rem] rounded-full'} h-[0.6rem] ${
@@ -40,7 +42,7 @@ export const NavbarDot = (active: boolean) =>
 
 // item-answer.tsx
 export const AnswerButton = (selected: boolean) =>
-  `w-[37.7rem] h-[4.5rem] rounded-[0.5rem] border-[0.1rem] text-[1.4rem] font-medium text-[var(--color-G2)] cursor-pointer ${
+  `w-full h-[4.5rem] rounded-[0.5rem] border-[0.1rem] text-[1.4rem] font-medium text-[var(--color-G2)] cursor-pointer ${
     selected
       ? 'border-[var(--color-mainColor1)] bg-[var(--color-subColor6)]'
       : 'border-[var(--color-G7)] bg-[var(--color-white)]'

--- a/src/styles/common/globalStyle.css
+++ b/src/styles/common/globalStyle.css
@@ -69,7 +69,7 @@
   }
 
   .mainContent {
-    @apply flex-1 w-full bg-white h-full;
+    @apply flex-1 w-full bg-white;
   }
 
   .font-hakgyoB {

--- a/src/styles/common/globalStyle.css
+++ b/src/styles/common/globalStyle.css
@@ -59,7 +59,7 @@
   }
 
   .pageContainer {
-    @apply flex flex-col items-center w-[425px] min-h-screen;
+    @apply flex flex-col items-center w-[425px] h-[100vh] relative;
   }
 
   @media screen and (max-width: 424px) {
@@ -69,7 +69,7 @@
   }
 
   .mainContent {
-    @apply flex-1 w-full bg-white;
+    @apply flex-1 w-full bg-white h-full;
   }
 
   .font-hakgyoB {

--- a/src/styles/footer/footer.style.ts
+++ b/src/styles/footer/footer.style.ts
@@ -1,9 +1,9 @@
 // footer.tsx
 export const FooterContainer =
-  'w-full bg-white h-[13rem] rounded-t-[2rem] flex justify-center pt-[1.3rem] shadow-[0_0_0.2rem_0_rgba(0,0,0,0.16)]';
+  'w-full max-w-[425px] bottom-0 fixed bg-white h-[13rem] rounded-t-[2rem] flex justify-center pt-[1.3rem] shadow-[0_0_0.2rem_0_rgba(0,0,0,0.16)]';
 
 // list-footer.tsx
-export const ListContainer = 'flex gap-[6rem]';
+export const ListContainer = 'w-full justify-between flex px-[5.6rem]';
 
 // item-footer.tsx
 export const ItemContainer =

--- a/src/styles/header/header.style.ts
+++ b/src/styles/header/header.style.ts
@@ -1,5 +1,5 @@
 export const HeaderContainer =
-  'w-full top-0 fixed h-[6rem] flex items-center mt-[2.4rem] px-[2.4rem]';
+  'w-full max-w-[425px] top-0 fixed h-[6rem] flex items-center pt-[2.4rem] px-[2.4rem]';
 
 export const LeftArrowImg = 'w-[0.98rem] h-[1.78rem] cursor-pointer';
 

--- a/src/styles/header/header.style.ts
+++ b/src/styles/header/header.style.ts
@@ -1,5 +1,5 @@
 export const HeaderContainer =
-  'w-full h-[6rem] flex items-center mt-[2.4rem] p-[2.4rem] relative';
+  'w-full top-0 fixed h-[6rem] flex items-center mt-[2.4rem] px-[2.4rem]';
 
 export const LeftArrowImg = 'w-[0.98rem] h-[1.78rem] cursor-pointer';
 

--- a/src/types/auth/mypage/mypage.ts
+++ b/src/types/auth/mypage/mypage.ts
@@ -19,5 +19,20 @@ export interface MypageResponse {
     nickname: string;
     profileImgUrl: string;
     representativeBadgeImageUrl: string;
+    userId: number;
+  };
+}
+
+export interface DeleteRequest {
+  userId: number;
+}
+
+export interface DeleteResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    userId: number;
+    message: string;
   };
 }


### PR DESCRIPTION
## 🚀 관련 이슈
- close #94 

## 🔑 작업 내용
- auth, header, footer 스타일링 수정
- 회원탈퇴 통신 연결

## 📷 스크린샷
- 상단에 header 고정, 하단에 footer 고정으로 변경했습니다.
<img width="1512" height="982" alt="스크린샷 2025-08-14 오후 11 18 14" src="https://github.com/user-attachments/assets/71eddc54-e48f-40d0-8239-30b975a7480d" />
<img width="1512" height="982" alt="스크린샷 2025-08-14 오후 11 18 46" src="https://github.com/user-attachments/assets/3dfe4f4a-f0d0-4887-b06b-c856007a5466" />
<img width="1512" height="982" alt="스크린샷 2025-08-14 오후 11 18 51" src="https://github.com/user-attachments/assets/fc052ba3-45b5-4491-a57f-ea0e06d404b4" />

## 🌐 공유 사항 to 리뷰어
- globalStyles에 main 클래스에 스크롤 지정하기엔 어느 페이지는 헤더/푸터가 없어서 별도로 지정해야 합니다.
- !h-[calc(100vh-13rem)] !mb-[13rem] !overflow-y-auto !pt-[8.4rem]을 각 페이지에서 잘 넣어주시면 좋을 것 같습니다. 스크롤 부분은 헤더랑 푸터를 제외한 부분만 되어야 합니다. 하다가 모르는 거 생기면 말해주세요!

## 🚨 이슈 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added account deletion from My Page menu with confirmation; on success, signs out and redirects to home.

- Style
  - Introduced customizable header background; applied no-background header on the test result screen.
  - Switched multiple auth, signup, and test pages to full-width, responsive layouts with consistent padding.
  - Adjusted My Feed and My Page to use viewport-based heights with internal scrolling.
  - Fixed header at the top and footer at the bottom within a mobile-width container.
  - Improved spacing on Agree, Setting, Onboarding, and Q&A screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->