### PR TITLE
🐛 Fix: 배지페이지 헤더/푸터 수정

### DIFF
--- a/src/pages/auth/mypage/mybadge.tsx
+++ b/src/pages/auth/mypage/mybadge.tsx
@@ -61,8 +61,8 @@ const Mybadge = () => {
 
   return (
     <div ref={wrapperRef} className={S.container}>
+      <Header title="MY 배지" />
       <div className={S.topContainer}>
-        <Header title="MY 배지" />
         <div className={S.titleContainer}>
           <div className={S.title}>대표 배지</div>
           <button className={S.editImage} onClick={() => setIsEditMode(true)}>

--- a/src/styles/auth/mypage/mybadge.style.ts
+++ b/src/styles/auth/mypage/mybadge.style.ts
@@ -29,7 +29,7 @@ export const badgeName =
   'mt-[1rem] text-[1.2rem] leading-[1.6rem] text-[var(--color-G1)] text-center';
 
 export const selectFooter =
-  'fixed bottom-0 left-0 w-full h-[13rem] bg-white rounded-t-[20px] flex justify-between px-[2.4rem] pt-[1.5rem] shadow-[0_0_2px_0_rgba(0,0,0,0.16)] gap-[2.3rem] z-50';
+  'fixed bottom-0 max-w-[425px] w-full h-[13rem] bg-white rounded-t-[20px] flex justify-between px-[2.4rem] pt-[1.5rem] shadow-[0_0_2px_0_rgba(0,0,0,0.16)] gap-[2.3rem] z-50';
 
 export const cancelButton =
   'flex-1 h-[4.7rem] bg-[var(--color-G7)] text-[2rem] text-[var(--color-G4)] rounded-[0.5rem]';

--- a/src/styles/auth/mypage/mybadge.style.ts
+++ b/src/styles/auth/mypage/mybadge.style.ts
@@ -1,6 +1,8 @@
-export const container = 'flex flex-col';
+export const container =
+  'flex-col !h-[calc(100vh-13rem)] !mb-[13rem] !overflow-y-auto !pt-[8.4rem]';
 
-export const topContainer = 'flex flex-col mx-[2.4rem]';
+export const topContainer =
+  'flex flex-col w-full mx-auto px-[1.6rem] mx-[2.4rem]';
 
 export const titleContainer = 'mt-[1rem] flex items-center gap-[0.6rem]';
 
@@ -27,7 +29,7 @@ export const badgeName =
   'mt-[1rem] text-[1.2rem] leading-[1.6rem] text-[var(--color-G1)] text-center';
 
 export const selectFooter =
-  'w-full max-w-[425px] h-[130px] bg-white rounded-t-[20px] flex justify-between px-[2.4rem] pt-[1.5rem] shadow-[0_0_2px_0_rgba(0,0,0,0.16)] gap-[2.3rem]';
+  'fixed bottom-0 left-0 w-full h-[13rem] bg-white rounded-t-[20px] flex justify-between px-[2.4rem] pt-[1.5rem] shadow-[0_0_2px_0_rgba(0,0,0,0.16)] gap-[2.3rem] z-50';
 
 export const cancelButton =
   'flex-1 h-[4.7rem] bg-[var(--color-G7)] text-[2rem] text-[var(--color-G4)] rounded-[0.5rem]';


### PR DESCRIPTION
## 🚀 관련 이슈

- close #102 

## 🔑 작업 내용

배지페이지 헤더/푸터 수정

## 📷 스크린샷

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/27f25b97-3915-433a-aba7-abbd71accd14" />

<img width="3840" height="1080" alt="image" src="https://github.com/user-attachments/assets/d81c20e8-79df-4b71-b608-0d5d852f03a7" />


## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Header now appears above the content area on the My Badge page.
  * Content area gains proper top padding and becomes vertically scrollable.
  * Layout width and horizontal padding adjusted for better centering and readability.
  * Action footer is now fixed at the bottom with improved layering, staying visible while scrolling.
  * Added bottom spacing to prevent content from being hidden behind the fixed footer.
  * Minor visual refinements; no changes to page logic or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->