### PR TITLE
🐛 Fix: 헤더 title 치우침 해결

### DIFF
--- a/src/styles/header/header.style.ts
+++ b/src/styles/header/header.style.ts
@@ -1,7 +1,7 @@
 export const HeaderContainer =
-  'w-full max-w-[425px] top-0 fixed h-[6rem] flex items-center pt-[2.4rem] px-[2.4rem]';
+  'w-full max-w-[425px] top-0 fixed h-[6rem] flex items-center pt-[2.4rem] pb-[1rem] px-[2.4rem]';
 
 export const LeftArrowImg = 'w-[0.98rem] h-[1.78rem] cursor-pointer';
 
 export const Title =
-  'absolute left-1/2 transform -translate-x-1/2 font-bold text-[1.8rem] text-[var(--color-G1)] whitespace-nowrap';
+  'w-full text-center font-bold text-[1.8rem] text-[var(--color-G1)] whitespace-nowrap mr-[0.98rem]';


### PR DESCRIPTION
## 🚀 관련 이슈

## 🔑 작업 내용
헤더 title 치우치는 현상 해결

## 📷 스크린샷
<img width="335" height="510" alt="스크린샷 2025-08-15 오후 3 25 09" src="https://github.com/user-attachments/assets/5e8b30e0-29f4-4e3f-94ab-fac263e74149" />

## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined header styling for improved visual balance.
  * Increased bottom padding to create clearer separation from content below, while keeping horizontal spacing unchanged.
  * Updated title to span full width and be center-aligned for better readability and consistent alignment across screen sizes.
  * Applied a small right-margin adjustment to the title to fine-tune spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->