### PR TITLE
🎨 Design: 가계부 관련 헤더, 푸터 UI 수정

### DIFF
--- a/src/pages/money/fixedcost.tsx
+++ b/src/pages/money/fixedcost.tsx
@@ -126,7 +126,6 @@ const FixedCost = () => {
             카테고리 선택<span>*</span>
           </Label>
 
-          {/* ✅ addday.tsx와 동일: 한 줄 + 가로 스크롤 */}
           <div style={{ overflowX: 'auto', paddingBottom: 4 }}>
             <CatBox
               style={{

--- a/src/pages/money/money.tsx
+++ b/src/pages/money/money.tsx
@@ -33,6 +33,7 @@ import {
 
 import {
   Container,
+  MainContainer,
   TopContainer,
   GreetingCard,
   GreetText,
@@ -367,466 +368,471 @@ const Money = () => {
 
   return (
     <Container>
-      <Header title="가계부" />
+      <Header title="가계부" bgColor="bg-[var(--color-B1)]" />
 
-      <TopContainer>
-        <GreetingCard>
-          <GreetText>
-            {nickname}
-            <span>
-              님!
-              <br />
-              소비 내역을 작성해 주세요.
-            </span>
-          </GreetText>
+      <MainContainer>
+        <TopContainer>
+          <GreetingCard>
+            <GreetText>
+              {nickname}
+              <span>
+                님!
+                <br />
+                소비 내역을 작성해 주세요.
+              </span>
+            </GreetText>
 
-          <MiniCard src={basicImage} alt="일러스트" />
-        </GreetingCard>
+            <MiniCard src={basicImage} alt="일러스트" />
+          </GreetingCard>
 
-        <MonthRow>
-          <ArrowBtn
-            src={LeftArrowActive}
-            alt="left"
-            onClick={prevMonth}
-            disabled={false}
-          />
-          <MonthText>{`${calMonth + 1}월`}</MonthText>
-          <ArrowBtn
-            style={{ transform: 'rotate(180deg)' }}
-            src={LeftArrowActive}
-            alt="right"
-            onClick={nextMonth}
-            disabled={isCurrentMonth}
-          />
-        </MonthRow>
+          <MonthRow>
+            <ArrowBtn
+              src={LeftArrowActive}
+              alt="left"
+              onClick={prevMonth}
+              disabled={false}
+            />
+            <MonthText>{`${calMonth + 1}월`}</MonthText>
+            <ArrowBtn
+              style={{ transform: 'rotate(180deg)' }}
+              src={LeftArrowActive}
+              alt="right"
+              onClick={nextMonth}
+              disabled={isCurrentMonth}
+            />
+          </MonthRow>
 
-        <TotalRow>
-          <TotalSpent>
-            {comma(usedAmt)}원
-            <span>
-              <span className="slash"> / </span>
-              {comma(totalBudgetAmt)}원
-            </span>
-          </TotalSpent>
-          <EditBtn
-            src={pencilIcon}
-            alt="edit"
-            onClick={() =>
-              navigate('/budget-register', {
-                state: {
-                  year: targetYear,
-                  month: targetMonth,
-                  budgetId: totalData?.result?.budgetId,
-                },
-              })
-            }
-          />
-        </TotalRow>
+          <TotalRow>
+            <TotalSpent>
+              {comma(usedAmt)}원
+              <span>
+                <span className="slash"> / </span>
+                {comma(totalBudgetAmt)}원
+              </span>
+            </TotalSpent>
+            <EditBtn
+              src={pencilIcon}
+              alt="edit"
+              onClick={() =>
+                navigate('/budget-register', {
+                  state: {
+                    year: targetYear,
+                    month: targetMonth,
+                    budgetId: totalData?.result?.budgetId,
+                  },
+                })
+              }
+            />
+          </TotalRow>
 
-        <BudgetCardWrapper>
-          <Summary>
-            {usedAmt > 0 ? (
-              <SummaryP>
-                한 달 예산 {comma(totalBudgetAmt)}원 중{' '}
-                <span>{comma(usedAmt)}원 </span>
-                사용했어요!
-              </SummaryP>
-            ) : (
-              <SummaryP>한 달 예산을 등록해주세요!</SummaryP>
-            )}
+          <BudgetCardWrapper>
+            <Summary>
+              {usedAmt > 0 ? (
+                <SummaryP>
+                  한 달 예산 {comma(totalBudgetAmt)}원 중{' '}
+                  <span>{comma(usedAmt)}원 </span>
+                  사용했어요!
+                </SummaryP>
+              ) : (
+                <SummaryP>한 달 예산을 등록해주세요!</SummaryP>
+              )}
 
-            <BarWrapper>
-              <Bar>
-                <Fill
-                  style={{
-                    width: `${fillPercent}%`,
-                    transition: 'width .4s ease',
-                  }}
+              <BarWrapper>
+                <Bar>
+                  <Fill
+                    style={{
+                      width: `${fillPercent}%`,
+                      transition: 'width .4s ease',
+                    }}
+                  />
+                </Bar>
+
+                <Below $fillPercent={fillPercent}>
+                  <span className="used-amount">
+                    <img src={starIcon} alt="star" />
+                    <span>{comma(usedAmt)}원</span>
+                  </span>
+                  <span
+                    style={{
+                      position: 'absolute',
+                      right: 0,
+                      bottom: '-0.6rem',
+                    }}
+                  >
+                    {comma(totalBudgetAmt)}원
+                  </span>
+                </Below>
+              </BarWrapper>
+            </Summary>
+          </BudgetCardWrapper>
+        </TopContainer>
+
+        <TabMenu>
+          <TabItemMenu>
+            {TAB_LIST.map((t) => (
+              <TabItem
+                key={t}
+                $active={activeTab === t}
+                onClick={() => setActiveTab(t)}
+              >
+                {t}
+              </TabItem>
+            ))}
+          </TabItemMenu>
+        </TabMenu>
+
+        <ContentArea>
+          {activeTab === '일일' && (
+            <>
+              <ButtonContainer>
+                <PlusBtn
+                  onClick={() => navigate('/add-day')}
+                  src={plusIcon}
+                  alt="plus"
                 />
-              </Bar>
 
-              <Below $fillPercent={fillPercent}>
-                <span className="used-amount">
-                  <img src={starIcon} alt="star" />
-                  <span>{comma(usedAmt)}원</span>
-                </span>
-                <span
-                  style={{ position: 'absolute', right: 0, bottom: '-0.6rem' }}
-                >
-                  {comma(totalBudgetAmt)}원
-                </span>
-              </Below>
-            </BarWrapper>
-          </Summary>
-        </BudgetCardWrapper>
-      </TopContainer>
-
-      <TabMenu>
-        <TabItemMenu>
-          {TAB_LIST.map((t) => (
-            <TabItem
-              key={t}
-              $active={activeTab === t}
-              onClick={() => setActiveTab(t)}
-            >
-              {t}
-            </TabItem>
-          ))}
-        </TabItemMenu>
-      </TabMenu>
-
-      <ContentArea>
-        {activeTab === '일일' && (
-          <>
-            <ButtonContainer>
-              <PlusBtn
-                onClick={() => navigate('/add-day')}
-                src={plusIcon}
-                alt="plus"
-              />
+                {(monthlyData?.pages?.[0]?.result?.monthlyHistory?.length ??
+                  0) > 0 && (
+                  <DeleteToggleBtn
+                    src={minusIcon}
+                    alt="minus"
+                    $active={deleteMode}
+                    onClick={() => setDeleteMode((v) => !v)}
+                  />
+                )}
+              </ButtonContainer>
 
               {(monthlyData?.pages?.[0]?.result?.monthlyHistory?.length ?? 0) >
-                0 && (
-                <DeleteToggleBtn
-                  src={minusIcon}
-                  alt="minus"
-                  $active={deleteMode}
-                  onClick={() => setDeleteMode((v) => !v)}
-                />
-              )}
-            </ButtonContainer>
+              0 ? (
+                monthlyData?.pages?.map((page) =>
+                  page.result.monthlyHistory.map((day) => {
+                    const dateObj = new Date(day.date);
+                    const dayNum = dateObj.getDate();
+                    const wd = WEEKDAY[dateObj.getDay()];
 
-            {(monthlyData?.pages?.[0]?.result?.monthlyHistory?.length ?? 0) >
-            0 ? (
-              monthlyData?.pages?.map((page) =>
-                page.result.monthlyHistory.map((day) => {
-                  const dateObj = new Date(day.date);
-                  const dayNum = dateObj.getDate();
-                  const wd = WEEKDAY[dateObj.getDay()];
+                    return (
+                      <Section key={day.date}>
+                        <DateRow>
+                          <span className="date">{`${dayNum} ${wd}`}</span>
+                        </DateRow>
 
-                  return (
-                    <Section key={day.date}>
-                      <DateRow>
-                        <span className="date">{`${dayNum} ${wd}`}</span>
-                      </DateRow>
+                        {day.items.map((item) => (
+                          <ItemRow key={item.consumptionRecordId}>
+                            <ItemRowLeft>
+                              <Dot $hide={deleteMode}>
+                                {item.categoryName === '[고정비]' ||
+                                item.categoryName === '고정비' ? (
+                                  <img src={fixedCostImage} alt="고정비" />
+                                ) : categoryImages[item.categoryName] ? (
+                                  <img
+                                    src={categoryImages[item.categoryName]}
+                                    alt={item.categoryName}
+                                  />
+                                ) : (
+                                  item.categoryName
+                                )}
+                              </Dot>
+                              <span className="memo">{item.content}</span>
+                            </ItemRowLeft>
 
-                      {day.items.map((item) => (
-                        <ItemRow key={item.consumptionRecordId}>
-                          <ItemRowLeft>
-                            <Dot $hide={deleteMode}>
-                              {item.categoryName === '[고정비]' ||
-                              item.categoryName === '고정비' ? (
-                                <img src={fixedCostImage} alt="고정비" />
-                              ) : categoryImages[item.categoryName] ? (
-                                <img
-                                  src={categoryImages[item.categoryName]}
-                                  alt={item.categoryName}
+                            <ItemRowRight>
+                              <span className="amount">
+                                {comma(item.amount)}원
+                              </span>
+
+                              {deleteMode && (
+                                <DeleteBtn
+                                  src={closeIcon}
+                                  alt="delete"
+                                  onClick={() =>
+                                    deleteEntry(item.consumptionRecordId)
+                                  }
                                 />
-                              ) : (
-                                item.categoryName
                               )}
-                            </Dot>
-                            <span className="memo">{item.content}</span>
-                          </ItemRowLeft>
-
-                          <ItemRowRight>
-                            <span className="amount">
-                              {comma(item.amount)}원
-                            </span>
-
-                            {deleteMode && (
-                              <DeleteBtn
-                                src={closeIcon}
-                                alt="delete"
-                                onClick={() =>
-                                  deleteEntry(item.consumptionRecordId)
-                                }
-                              />
-                            )}
-                          </ItemRowRight>
-                        </ItemRow>
-                      ))}
-                    </Section>
-                  );
-                }),
-              )
-            ) : (
-              <EmptyBox>
-                <EmptyCircle src={emptyImage} alt="비어 있음" />
-                <EmptyText>등록된 소비 내역이 없어요.</EmptyText>
-              </EmptyBox>
-            )}
-
-            {hasNextPage && <div ref={loadMoreRef} style={{ height: 40 }} />}
-          </>
-        )}
-
-        {activeTab === '달력' && (
-          <>
-            <CalendarWrap>
-              <WeekRow>
-                {WEEKDAY.map((w) => (
-                  <WeekCell key={w}>{w}</WeekCell>
-                ))}
-              </WeekRow>
-
-              <DayGrid>
-                {calendarCells.map((d, i) => {
-                  if (!d) return <DayCell key={`empty-${i}`} />;
-
-                  const dateStr = `${calYear}-${String(calMonth + 1).padStart(
-                    2,
-                    '0',
-                  )}-${String(d).padStart(2, '0')}`;
-
-                  const daySpent = calendarData?.result?.data?.[dateStr] ?? 0;
-                  const isSelected = selectedDate === dateStr;
-
-                  return (
-                    <DayCell key={dateStr}>
-                      <DayNumButton
-                        $selected={isSelected}
-                        onClick={() => toggleDate(dateStr)}
-                      >
-                        {d}
-                      </DayNumButton>
-
-                      {daySpent !== 0 && (
-                        <SpendPill $minus={true}>
-                          -{comma(Math.abs(daySpent))}
-                        </SpendPill>
-                      )}
-
-                      {(i + 1) % 7 === 0 && i + 1 !== calendarCells.length && (
-                        <WeekDivider />
-                      )}
-                    </DayCell>
-                  );
-                })}
-              </DayGrid>
-            </CalendarWrap>
-
-            {selectedDate && (
-              <CalListSection
-                style={{
-                  transform: `translateY(${dragOffset}px)`,
-                  transition: anim ? 'transform 0.25s ease' : 'none',
-                }}
-                onPointerDown={onDragStart}
-                onPointerMove={onDragMove}
-                onPointerUp={onDragEnd}
-              >
-                <SheetHandle />
-
-                <CalDateTitle>
-                  {new Date(selectedDate).getDate()}{' '}
-                  {WEEKDAY[new Date(selectedDate).getDay()]}
-                </CalDateTitle>
-
-                {selectedList.length ? (
-                  selectedList.map((item) => (
-                    <CalItemRow key={item.consumptionRecordId}>
-                      <CalDot>
-                        {item.categoryName === '[고정비]' ||
-                        item.categoryName === '고정비' ? (
-                          <img src={fixedCostImage} alt="고정비" />
-                        ) : categoryImages[item.categoryName] ? (
-                          <img
-                            src={categoryImages[item.categoryName]}
-                            alt={item.categoryName}
-                          />
-                        ) : (
-                          item.categoryName
-                        )}
-                      </CalDot>
-                      <span className="memo">{item.content}</span>
-                      <span className="amount">{comma(item.amount)}원</span>
-                    </CalItemRow>
-                  ))
-                ) : (
-                  <EmptyBoxSmall>해당 날짜에 기록이 없어요.</EmptyBoxSmall>
-                )}
-
-                <FloatingPlus onClick={() => navigate('/record')}>
-                  <img src={plusCircle} alt="add" />
-                </FloatingPlus>
-              </CalListSection>
-            )}
-          </>
-        )}
-
-        {activeTab === '고정비' && (
-          <>
-            <ButtonContainer>
-              <PlusBtn
-                onClick={() => navigate('/fixed-cost')}
-                src={plusIcon}
-                alt="plus"
-              />
-
-              {fixedItems.length > 0 && (
-                <DeleteToggleBtn
-                  src={minusIcon}
-                  alt="minus"
-                  $active={fixedDel}
-                  onClick={() => setFixedDel((v) => !v)}
-                />
+                            </ItemRowRight>
+                          </ItemRow>
+                        ))}
+                      </Section>
+                    );
+                  }),
+                )
+              ) : (
+                <EmptyBox>
+                  <EmptyCircle src={emptyImage} alt="비어 있음" />
+                  <EmptyText>등록된 소비 내역이 없어요.</EmptyText>
+                </EmptyBox>
               )}
-            </ButtonContainer>
 
-            {fixedItems.length ? (
-              <Section2>
-                {fixedItems.map((e) => (
-                  <ItemRow key={e.fixedConsumptionId}>
-                    <ItemRowLeft>
-                      <Dot>
-                        <img src={fixedCostImage} alt="fixed cost" />
-                      </Dot>
-                      <span className="memo">
-                        {e.memo || e.categoryName || ''}
-                      </span>
-                    </ItemRowLeft>
+              {hasNextPage && <div ref={loadMoreRef} style={{ height: 40 }} />}
+            </>
+          )}
 
-                    <ItemRowRight>
-                      <span className="amount">{comma(e.amount)}원</span>
+          {activeTab === '달력' && (
+            <>
+              <CalendarWrap>
+                <WeekRow>
+                  {WEEKDAY.map((w) => (
+                    <WeekCell key={w}>{w}</WeekCell>
+                  ))}
+                </WeekRow>
 
-                      {fixedDel && (
-                        <DeleteBtn
-                          src={closeIcon}
-                          alt="close"
-                          onClick={() => deleteFixed(e.fixedConsumptionId)}
-                          style={{
-                            opacity: isDeletingFixed ? 0.6 : 1,
-                            pointerEvents: isDeletingFixed ? 'none' : 'auto',
-                          }}
-                        />
-                      )}
-                    </ItemRowRight>
-                  </ItemRow>
-                ))}
+                <DayGrid>
+                  {calendarCells.map((d, i) => {
+                    if (!d) return <DayCell key={`empty-${i}`} />;
 
-                {hasNextFixed && (
-                  <div ref={fixedLoadMoreRef} style={{ height: 40 }} />
-                )}
-              </Section2>
-            ) : (
-              <EmptyBox>
-                <EmptyCircle src={emptyImage} alt="비어 있음" />
-                <EmptyText>등록된 고정비가 없어요.</EmptyText>
-              </EmptyBox>
-            )}
-          </>
-        )}
+                    const dateStr = `${calYear}-${String(calMonth + 1).padStart(
+                      2,
+                      '0',
+                    )}-${String(d).padStart(2, '0')}`;
 
-        {activeTab === '소비 루틴' && (
-          <>
-            <ButtonContainer>
-              <PlusBtn
-                onClick={() =>
-                  navigate('/money-routine', {
-                    state: { budgetId: totalData?.result?.budgetId ?? 0 },
-                  })
-                }
-                src={plusIcon}
-                alt="plus"
-              />
-            </ButtonContainer>
+                    const daySpent = calendarData?.result?.data?.[dateStr] ?? 0;
+                    const isSelected = selectedDate === dateStr;
 
-            {routines.length ? (
-              <RoutineCardList>
-                {routines.map((r) => {
-                  const date = new Date(r.createDate);
-                  const dateStr = `${date.getFullYear()} • ${String(
-                    date.getMonth() + 1,
-                  ).padStart(2, '0')} • ${String(date.getDate()).padStart(
-                    2,
-                    '0',
-                  )}`;
-
-                  const imgUrl = resolveRoutineImageUrl(r);
-
-                  return (
-                    <RoutineWideCard
-                      key={r.routineId}
-                      onClick={() =>
-                        navigate(`/myroutine/${r.routineId}`, {
-                          state: { from: 'money' },
-                        })
-                      }
-                      style={{ overflow: 'visible' }}
-                    >
-                      <PreviewBox
-                        style={
-                          imgUrl
-                            ? {
-                                backgroundImage: `url(${imgUrl})`,
-                                backgroundSize: 'contain',
-                                backgroundRepeat: 'no-repeat',
-                                backgroundPosition: 'left center',
-                                backgroundColor: '#fff',
-                              }
-                            : undefined
-                        }
-                      />
-
-                      <RoutineContent style={{ overflow: 'visible' }}>
-                        <DateLine>{dateStr}</DateLine>
-
-                        {/* 제목 잘림 방지 */}
-                        <TitleRow
-                          style={{
-                            overflow: 'visible',
-                            alignItems: 'flex-start',
-                          }}
+                    return (
+                      <DayCell key={dateStr}>
+                        <DayNumButton
+                          $selected={isSelected}
+                          onClick={() => toggleDate(dateStr)}
                         >
-                          <h3
-                            className="title"
+                          {d}
+                        </DayNumButton>
+
+                        {daySpent !== 0 && (
+                          <SpendPill $minus={true}>
+                            -{comma(Math.abs(daySpent))}
+                          </SpendPill>
+                        )}
+
+                        {(i + 1) % 7 === 0 &&
+                          i + 1 !== calendarCells.length && <WeekDivider />}
+                      </DayCell>
+                    );
+                  })}
+                </DayGrid>
+              </CalendarWrap>
+
+              {selectedDate && (
+                <CalListSection
+                  style={{
+                    transform: `translateY(${dragOffset}px)`,
+                    transition: anim ? 'transform 0.25s ease' : 'none',
+                  }}
+                  onPointerDown={onDragStart}
+                  onPointerMove={onDragMove}
+                  onPointerUp={onDragEnd}
+                >
+                  <SheetHandle />
+
+                  <CalDateTitle>
+                    {new Date(selectedDate).getDate()}{' '}
+                    {WEEKDAY[new Date(selectedDate).getDay()]}
+                  </CalDateTitle>
+
+                  {selectedList.length ? (
+                    selectedList.map((item) => (
+                      <CalItemRow key={item.consumptionRecordId}>
+                        <CalDot>
+                          {item.categoryName === '[고정비]' ||
+                          item.categoryName === '고정비' ? (
+                            <img src={fixedCostImage} alt="고정비" />
+                          ) : categoryImages[item.categoryName] ? (
+                            <img
+                              src={categoryImages[item.categoryName]}
+                              alt={item.categoryName}
+                            />
+                          ) : (
+                            item.categoryName
+                          )}
+                        </CalDot>
+                        <span className="memo">{item.content}</span>
+                        <span className="amount">{comma(item.amount)}원</span>
+                      </CalItemRow>
+                    ))
+                  ) : (
+                    <EmptyBoxSmall>해당 날짜에 기록이 없어요.</EmptyBoxSmall>
+                  )}
+
+                  <FloatingPlus onClick={() => navigate('/record')}>
+                    <img src={plusCircle} alt="add" />
+                  </FloatingPlus>
+                </CalListSection>
+              )}
+            </>
+          )}
+
+          {activeTab === '고정비' && (
+            <>
+              <ButtonContainer>
+                <PlusBtn
+                  onClick={() => navigate('/fixed-cost')}
+                  src={plusIcon}
+                  alt="plus"
+                />
+
+                {fixedItems.length > 0 && (
+                  <DeleteToggleBtn
+                    src={minusIcon}
+                    alt="minus"
+                    $active={fixedDel}
+                    onClick={() => setFixedDel((v) => !v)}
+                  />
+                )}
+              </ButtonContainer>
+
+              {fixedItems.length ? (
+                <Section2>
+                  {fixedItems.map((e) => (
+                    <ItemRow key={e.fixedConsumptionId}>
+                      <ItemRowLeft>
+                        <Dot>
+                          <img src={fixedCostImage} alt="fixed cost" />
+                        </Dot>
+                        <span className="memo">
+                          {e.memo || e.categoryName || ''}
+                        </span>
+                      </ItemRowLeft>
+
+                      <ItemRowRight>
+                        <span className="amount">{comma(e.amount)}원</span>
+
+                        {fixedDel && (
+                          <DeleteBtn
+                            src={closeIcon}
+                            alt="close"
+                            onClick={() => deleteFixed(e.fixedConsumptionId)}
                             style={{
-                              margin: 0,
-                              lineHeight: 1.35,
-                              paddingBottom: 2,
+                              opacity: isDeletingFixed ? 0.6 : 1,
+                              pointerEvents: isDeletingFixed ? 'none' : 'auto',
+                            }}
+                          />
+                        )}
+                      </ItemRowRight>
+                    </ItemRow>
+                  ))}
+
+                  {hasNextFixed && (
+                    <div ref={fixedLoadMoreRef} style={{ height: 40 }} />
+                  )}
+                </Section2>
+              ) : (
+                <EmptyBox>
+                  <EmptyCircle src={emptyImage} alt="비어 있음" />
+                  <EmptyText>등록된 고정비가 없어요.</EmptyText>
+                </EmptyBox>
+              )}
+            </>
+          )}
+
+          {activeTab === '소비 루틴' && (
+            <>
+              <ButtonContainer>
+                <PlusBtn
+                  onClick={() =>
+                    navigate('/money-routine', {
+                      state: { budgetId: totalData?.result?.budgetId ?? 0 },
+                    })
+                  }
+                  src={plusIcon}
+                  alt="plus"
+                />
+              </ButtonContainer>
+
+              {routines.length ? (
+                <RoutineCardList>
+                  {routines.map((r) => {
+                    const date = new Date(r.createDate);
+                    const dateStr = `${date.getFullYear()} • ${String(
+                      date.getMonth() + 1,
+                    ).padStart(2, '0')} • ${String(date.getDate()).padStart(
+                      2,
+                      '0',
+                    )}`;
+
+                    const imgUrl = resolveRoutineImageUrl(r);
+
+                    return (
+                      <RoutineWideCard
+                        key={r.routineId}
+                        onClick={() =>
+                          navigate(`/myroutine/${r.routineId}`, {
+                            state: { from: 'money' },
+                          })
+                        }
+                        style={{ overflow: 'visible' }}
+                      >
+                        <PreviewBox
+                          style={
+                            imgUrl
+                              ? {
+                                  backgroundImage: `url(${imgUrl})`,
+                                  backgroundSize: 'contain',
+                                  backgroundRepeat: 'no-repeat',
+                                  backgroundPosition: 'left center',
+                                  backgroundColor: '#fff',
+                                }
+                              : undefined
+                          }
+                        />
+
+                        <RoutineContent style={{ overflow: 'visible' }}>
+                          <DateLine>{dateStr}</DateLine>
+
+                          {/* 제목 잘림 방지 */}
+                          <TitleRow
+                            style={{
                               overflow: 'visible',
-                              display: 'inline-block',
+                              alignItems: 'flex-start',
                             }}
                           >
-                            {r.routineName}
-                          </h3>
-                          <ArrowIcon src={arrowIconImg} alt="arrow" />
-                        </TitleRow>
+                            <h3
+                              className="title"
+                              style={{
+                                margin: 0,
+                                lineHeight: 1.35,
+                                paddingBottom: 2,
+                                overflow: 'visible',
+                                display: 'inline-block',
+                              }}
+                            >
+                              {r.routineName}
+                            </h3>
+                            <ArrowIcon src={arrowIconImg} alt="arrow" />
+                          </TitleRow>
 
-                        <TagsRow>
-                          {(r.hashtags ?? []).map((t) => {
-                            const tag = t.startsWith('#') ? t : `#${t}`;
-                            return (
-                              <span className="tag" key={tag}>
-                                {tag}
-                              </span>
-                            );
-                          })}
-                        </TagsRow>
+                          <TagsRow>
+                            {(r.hashtags ?? []).map((t) => {
+                              const tag = t.startsWith('#') ? t : `#${t}`;
+                              return (
+                                <span className="tag" key={tag}>
+                                  {tag}
+                                </span>
+                              );
+                            })}
+                          </TagsRow>
 
-                        <UserRow>
-                          <Avatar />
-                          <span className="nick">{r.nickname || '라인'}</span>
-                        </UserRow>
-                      </RoutineContent>
-                    </RoutineWideCard>
-                  );
-                })}
+                          <UserRow>
+                            <Avatar />
+                            <span className="nick">{r.nickname || '라인'}</span>
+                          </UserRow>
+                        </RoutineContent>
+                      </RoutineWideCard>
+                    );
+                  })}
 
-                {hasNextRoutines && (
-                  <div ref={routineLoadMoreRef} style={{ height: 40 }} />
-                )}
-              </RoutineCardList>
-            ) : (
-              <EmptyBox>
-                <EmptyCircle src={emptyImage} alt="비어 있음" />
-                <EmptyText>등록된 소비 루틴이 없어요.</EmptyText>
-              </EmptyBox>
-            )}
-          </>
-        )}
-      </ContentArea>
+                  {hasNextRoutines && (
+                    <div ref={routineLoadMoreRef} style={{ height: 40 }} />
+                  )}
+                </RoutineCardList>
+              ) : (
+                <EmptyBox>
+                  <EmptyCircle src={emptyImage} alt="비어 있음" />
+                  <EmptyText>등록된 소비 루틴이 없어요.</EmptyText>
+                </EmptyBox>
+              )}
+            </>
+          )}
+        </ContentArea>
+      </MainContainer>
     </Container>
   );
 };

--- a/src/pages/money/registration.tsx
+++ b/src/pages/money/registration.tsx
@@ -270,7 +270,7 @@ const BudgetRegister = () => {
 
   return (
     <Wrap>
-      <Header title="예산 등록" />
+      <Header title="예산 등록" bgColor="bg-[var(--color-B1)]" />
 
       <Body>
         <Section>

--- a/src/styles/budget/addcategory.styles.ts
+++ b/src/styles/budget/addcategory.styles.ts
@@ -3,15 +3,17 @@ import colors from '../common/colors';
 
 export const Wrap = styled.div`
   position: relative;
+  padding-top: 8.4rem;
   width: 100%;
   height: 100vh;
   background: ${colors.white};
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 `;
 
 export const Body = styled.main`
-  padding: 4.2rem 2.4rem 0 2.4rem;
+  padding: 0 2.4rem 0 2.4rem;
 `;
 
 export const InputWrapper = styled.div`

--- a/src/styles/budget/fixedcost.styles.ts
+++ b/src/styles/budget/fixedcost.styles.ts
@@ -3,15 +3,16 @@ import colors from '../common/colors';
 
 export const Wrap = styled.div`
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
+  padding-top: 8.4rem;
 `;
 
 export const Body = styled.main`
   width: 100%;
-  margin-top: 2.6rem;
+  overflow-y: auto;
 `;
 
 export const Section = styled.section`

--- a/src/styles/budget/money.styles.ts
+++ b/src/styles/budget/money.styles.ts
@@ -2,11 +2,17 @@ import styled, { css } from 'styled-components';
 import colors from '../common/colors';
 
 export const Container = styled.div`
+  padding: 8.4rem 0 13rem 0;
   width: 100%;
+  height: 100vh;
   background: ${colors.B1};
   display: flex;
   flex-direction: column;
   align-items: center;
+`;
+
+export const MainContainer = styled.div`
+  overflow-y: auto;
 `;
 
 export const TopContainer = styled.div`
@@ -22,7 +28,7 @@ export const GreetingCard = styled.section`
   display: flex;
   gap: 2.2rem;
   align-items: center;
-  margin: 1rem 0 2.4rem 0;
+  margin: 0 0 2.4rem 0;
 `;
 
 export const GreetText = styled.p`
@@ -129,7 +135,7 @@ export const SummaryP = styled.p`
 
 export const BarWrapper = styled.div`
   width: 100%;
-  position: relative; /* 별/텍스트 절대배치 기준 */
+  position: relative;
   height: 3.9rem;
   display: flex;
   justify-content: center;
@@ -151,11 +157,10 @@ export const Fill = styled.div`
   transition: width 0.25s ease;
 `;
 
-/* ★ 바와 동일 기준(98% 너비)에 맞춰 별 위치 보정 */
 export const Below = styled.div<{ $fillPercent: number }>`
   position: absolute;
-  left: 1%; /* Bar 좌측 여백(100%-98%)의 절반 = 1% */
-  width: 98%; /* Bar와 동일한 기준 너비 */
+  left: 1%;
+  width: 98%;
   bottom: 0;
   font-size: 1.1rem;
   font-weight: 300;
@@ -169,7 +174,6 @@ export const Below = styled.div<{ $fillPercent: number }>`
     flex-direction: column;
     align-items: center;
 
-    /* 게이지 끝과 정확히 일치 (0~100% 클램프 + 중심 보정) */
     left: ${({ $fillPercent }) =>
       $fillPercent <= 0
         ? '0'
@@ -211,6 +215,7 @@ export const TabItem = styled.button<{ $active: boolean }>`
   font-weight: 500;
   cursor: pointer;
   position: relative;
+  padding-bottom: 0.6rem;
 
   ${({ $active }) =>
     $active &&

--- a/src/styles/budget/myroutine.styles.ts
+++ b/src/styles/budget/myroutine.styles.ts
@@ -3,14 +3,15 @@ import colors from '../common/colors';
 
 export const Wrap = styled.div`
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
+  padding-top: 8.4rem;
 `;
 
 export const Body = styled.main`
-  margin-top: 2.6rem;
+  overflow-y: auto;
 `;
 
 export const Section = styled.section`

--- a/src/styles/budget/registration.styles.ts
+++ b/src/styles/budget/registration.styles.ts
@@ -4,16 +4,17 @@ import colors from '../common/colors';
 export const Wrap = styled.div`
   position: relative;
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   background: ${colors.B1};
   display: flex;
   flex-direction: column;
   align-items: center;
+  padding-top: 8.4rem;
+  overflow-y: auto;
 `;
 
 export const Body = styled.main`
   width: 100%;
-  margin-top: 2.6rem;
 `;
 
 export const Section = styled.section`
@@ -153,17 +154,21 @@ export const ConfirmBtn = styled.button<{ disabled?: boolean }>`
 
 // 모달
 export const Dim = styled.div`
+  width 100%;
+  max-width: 425px;
   position: absolute;
   inset: 0;
   z-index: 999;
   background: rgba(17, 17, 17, 0.6);
-  // backdrop-filter: blur(0.2rem);
   display: flex;
   align-items: flex-end;
+  overflow-y: auto;
 `;
 
 export const Modal = styled.div`
+  position: fixed;
   width: 100%;
+  max-width: 425px;
   background: ${colors.white};
   border-radius: 1.5rem 1.5rem 0 0;
   display: flex;

--- a/src/styles/budget/routine.styles.ts
+++ b/src/styles/budget/routine.styles.ts
@@ -3,15 +3,15 @@ import colors from '../common/colors';
 
 export const Wrap = styled.div`
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
+  padding-top: 8.4rem;
+  overflow-y: auto;
 `;
 
-export const Body = styled.main`
-  margin-top: 2.6rem;
-`;
+export const Body = styled.main``;
 
 export const Section = styled.section`
   margin: 0 2.4rem;
@@ -129,16 +129,21 @@ export const ConfirmBtn = styled.button<{ disabled?: boolean }>`
 `;
 
 export const Dim = styled.div`
+  width 100%;
+  max-width: 425px;
   position: absolute;
   inset: 0;
   z-index: 999;
   background: rgba(17, 17, 17, 0.6);
   display: flex;
   align-items: flex-end;
+  overflow-y: auto;
 `;
 
 export const Modal = styled.div`
+  position: fixed;
   width: 100%;
+  max-width: 425px;
   background: ${colors.white};
   border-radius: 1.5rem 1.5rem 0 0;
   display: flex;

--- a/src/styles/budget/routineregistration.styles.ts
+++ b/src/styles/budget/routineregistration.styles.ts
@@ -3,14 +3,16 @@ import colors from '../common/colors';
 
 export const Wrap = styled.div`
   width: 100%;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
   position: relative;
+  padding-top: 8.4rem;
 `;
 
 export const Body = styled.main`
-  margin: 2.6rem 2.4rem 0 2.4rem;
+  padding: 0 2.4rem;
+  overflow-y: auto;
 `;
 
 export const InputWrapper = styled.div`
@@ -132,7 +134,7 @@ export const MeasureSpan = styled.span`
 `;
 
 export const Save = styled.button<{ disabled?: boolean }>`
-  margin: 44.5rem 0 16.4rem 0;
+  margin: 44.5rem 0 0 0;
   width: 100%;
   height: 5rem;
   border: none;


### PR DESCRIPTION
## 🚀 관련 이슈

## 🔑 작업 내용
가계부 헤더, 푸터 UI 수정

## 📷 스크린샷
<img width="1512" height="982" alt="스크린샷 2025-08-15 오후 6 36 29" src="https://github.com/user-attachments/assets/2fa0d4a7-d1a5-4076-aa3e-893544520888" />

## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Refreshed Money page layout with a containerized structure and colorized header.
  - Enhanced budget gauge with a “used vs total” display and star indicator.
  - Daily view gains a delete toggle and smoother delete flow.
  - Fixed-cost tab aligns to new sections with delete controls and load-more support.
  - Routine cards now show richer previews, metadata, and visuals.

- Style/Refactor
  - Unified vertical spacing and scrolling across budget pages (full-height views, top padding).
  - Improved modal positioning and mobile width handling.
  - Minor alignment and overflow tweaks for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->