### PR TITLE
✨ Feat: 가계부 UI 리팩토링

### DIFF
--- a/src/pages/money/money.tsx
+++ b/src/pages/money/money.tsx
@@ -111,7 +111,6 @@ const categoryImages: Record<string, string> = {
   고정비: fixedCostImage,
 };
 
-// ---- 레거시 필드(routineImageUrl) 호환 ----
 type RoutineItemWithLegacyImage = RoutineListItem & {
   routineImageUrl?: string;
 };
@@ -269,7 +268,6 @@ const Money = () => {
     }
   }, [location.state]);
 
-  // 일일 삭제
   const deleteEntry = async (id: number) => {
     try {
       const res = await callDailyDeleteMutation(id);
@@ -282,7 +280,6 @@ const Money = () => {
     }
   };
 
-  // 고정비 삭제
   const { mutate: deleteFixedCostMutate, isPending: isDeletingFixed } =
     useFixedCostDeleteMutation();
 
@@ -303,9 +300,19 @@ const Money = () => {
     });
   };
 
-  // ===== 게이지 값(두 번째 스샷처럼) : API 값 기준 =====
   const totalBudgetAmt = data?.result?.totalBudget ?? 0;
-  const usedAmt = totalData?.result?.totalConsumptionAmount ?? 0;
+
+  const variableUsedAmt = totalData?.result?.totalConsumptionAmount ?? 0;
+
+  const fixedUsedAmt =
+    fixedListData?.pages?.reduce((sum, page) => {
+      const list = page?.result?.fixedConsumptions ?? [];
+      const pageSum = list.reduce((s, it) => s + (it?.amount ?? 0), 0);
+      return sum + pageSum;
+    }, 0) ?? 0;
+
+  const usedAmt = variableUsedAmt + fixedUsedAmt;
+
   const fillPercent = totalBudgetAmt
     ? Math.min((usedAmt / totalBudgetAmt) * 100, 100)
     : 0;
@@ -336,7 +343,6 @@ const Money = () => {
     startYRef.current = 0;
   };
 
-  // ===== 소비 루틴 목록 =====
   const {
     data: routinesPages,
     fetchNextPage: fetchNextRoutines,
@@ -777,7 +783,6 @@ const Money = () => {
                         <RoutineContent style={{ overflow: 'visible' }}>
                           <DateLine>{dateStr}</DateLine>
 
-                          {/* 제목 잘림 방지 */}
                           <TitleRow
                             style={{
                               overflow: 'visible',

--- a/src/styles/budget/money.styles.ts
+++ b/src/styles/budget/money.styles.ts
@@ -13,6 +13,7 @@ export const Container = styled.div`
 
 export const MainContainer = styled.div`
   overflow-y: auto;
+  width: 100%;
 `;
 
 export const TopContainer = styled.div`
@@ -175,9 +176,8 @@ export const Below = styled.div<{ $fillPercent: number }>`
     align-items: center;
 
     left: ${({ $fillPercent }) =>
-      $fillPercent <= 0
-        ? '0'
-        : `calc(${Math.min($fillPercent, 100)}% - 1.5rem)`};
+      `${Math.min(Math.max($fillPercent, 0), 100)}%`};
+    transform: translateX(-50%);
 
     img {
       width: 1.6rem;
@@ -197,7 +197,6 @@ export const TabMenu = styled.nav`
   height: 4.3rem;
   display: flex;
   justify-content: center;
-  // background: ${colors.white};
   border-radius: 1.5rem 1.5rem 0 0;
   border-bottom: 0.1rem solid ${colors.G7};
   box-shadow: 0 0 1rem 0 #0000000d;
@@ -236,6 +235,7 @@ export const TabItem = styled.button<{ $active: boolean }>`
 
 export const ContentArea = styled.div`
   background: ${colors.white};
+  height: 100%;
   width: 100%;
   position: relative;
   padding-top: 2.71rem;
@@ -331,7 +331,6 @@ export const Dot = styled.span<{ $hide?: boolean }>`
   }
 `;
 
-// 비어있을 때
 export const EmptyBox = styled.div`
   margin: 12.3rem 0 25.9rem 0;
   display: flex;
@@ -500,19 +499,23 @@ export const DayNumButton = styled.button<{ $selected: boolean }>`
   color: ${({ $selected }) => ($selected ? `${colors.mainColor1}` : colors.G1)};
 `;
 
-export const SpendPill = styled.div<{ $minus: boolean }>`
+/* 달력 금액 배지: 내용 길이에 딱 맞게 */
+export const SpendPill = styled.span<{ $minus: boolean }>`
   margin-top: 0.5rem;
-  padding: 0 4px;
+  padding: 0 6px;
   height: 1.6rem;
-  min-width: 4.1rem;
   border-radius: 0.5rem;
   font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
   color: ${colors.subColor1};
   background: ${({ $minus }) =>
     $minus ? `${colors.subColor5}` : 'transparent'};
 `;
 
-/* 여기서부터 수정된 하단 시트/달력 리스트 영역 */
+/* 하단 시트 */
 export const CalListSection = styled.section`
   padding: 16px;
   background: #f0fff9;

--- a/src/styles/budget/routine.styles.ts
+++ b/src/styles/budget/routine.styles.ts
@@ -73,6 +73,11 @@ export const CatLi = styled.li<{ $editable: boolean }>`
   font-weight: 500;
   color: ${colors.G1};
 
+  & > span:first-child {
+    color: ${colors.G5};
+    font-size: 1.5rem;
+  }
+
   .CatP {
     color: ${colors.G5};
     font-size: 1.5rem;
@@ -129,7 +134,7 @@ export const ConfirmBtn = styled.button<{ disabled?: boolean }>`
 `;
 
 export const Dim = styled.div`
-  width 100%;
+  width: 100%;
   max-width: 425px;
   position: absolute;
   inset: 0;


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) ✨ feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #113 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
게이지바와 별의 위치 알맞게 수정
달력 탭 1000원대 이해 금액 박스 안에 알맞게 위치하도록 수정
소비 루틴 추가할 때 내가 추가한 카테고리 제목의 색 수정

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
<img width="439" height="169" alt="image" src="https://github.com/user-attachments/assets/ea3a0f03-f297-4fa2-8530-582f1e252ab5" />
<img width="277" height="398" alt="image" src="https://github.com/user-attachments/assets/e5993b04-7d80-4f10-8d05-6d6252da1a46" />
<img width="287" height="222" alt="image" src="https://github.com/user-attachments/assets/a350b0e6-17ed-43a4-bc86-42163c3e1351" />


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * More accurate budget gauge by combining variable and fixed spending.
  * Routine image handling updated to align with current paths.
  * Full-width layout for main container; content area now fills available height.

* **Bug Fixes**
  * Corrected overlay width styling to ensure proper screen coverage.

* **Style**
  * Gauge used-amount label is centered and clamped within the bar.
  * Spend pill refined (inline display, tighter padding, no wrapping) for clearer readability.
  * Routine list first label styled for improved hierarchy and legibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->