### PR TITLE
✨ Feat: 가계부 UI 리팩토링

### DIFF
--- a/src/pages/money/money.tsx
+++ b/src/pages/money/money.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Header from '../../components/header/header';
 import LeftArrowActive from '../../assets/images/budget/leftArrowActive.png';
@@ -30,6 +30,8 @@ import {
   useMyRoutinesQuery,
   type RoutineItem as RoutineListItem,
 } from '../../hooks/money/routine/useMyRoutinesQuery';
+
+// Tailwind class names
 import * as A from '../../styles/budget/money.styles';
 
 const TAB_LIST = ['일일', '달력', '고정비', '소비 루틴'] as const;
@@ -199,7 +201,7 @@ const Money = () => {
 
   useEffect(() => {
     const tab = (location.state as { tab?: string } | null)?.tab;
-    if (tab && TAB_LIST.includes(tab as (typeof TAB_LIST)[number])) {
+    if (tab && (TAB_LIST as readonly string[]).includes(tab)) {
       setActiveTab(tab as (typeof TAB_LIST)[number]);
     }
   }, [location.state]);
@@ -237,7 +239,6 @@ const Money = () => {
   };
 
   const totalBudgetAmt = data?.result?.totalBudget ?? 0;
-
   const variableUsedAmt = totalData?.result?.totalConsumptionAmount ?? 0;
 
   const fixedUsedAmt =
@@ -309,50 +310,59 @@ const Money = () => {
   }, [activeTab, hasNextRoutines, isFetchingNextRoutines, fetchNextRoutines]);
 
   return (
-    <A.Container>
+    <div className={A.Container}>
       <Header title="가계부" bgColor="bg-[var(--color-B1)]" />
 
-      <A.MainContainer>
-        <A.TopContainer>
-          <A.GreetingCard>
-            <A.GreetText>
+      <main className={A.MainContainer}>
+        <div className={A.TopContainer}>
+          <section
+            className={A.GreetingCard}
+            style={{
+              background:
+                'linear-gradient(135deg, var(--color-subColor3) 0%, #4be3a5 100%)',
+            }}
+          >
+            <p className={A.GreetText}>
               {nickname}
-              <span>
+              <span className="font-medium">
                 님!
                 <br />
                 소비 내역을 작성해 주세요.
               </span>
-            </A.GreetText>
+            </p>
 
-            <A.MiniCard src={basicImage} alt="일러스트" />
-          </A.GreetingCard>
+            <img className={A.MiniCard} src={basicImage} alt="일러스트" />
+          </section>
 
-          <A.MonthRow>
-            <A.ArrowBtn
+          <div className={A.MonthRow}>
+            <img
+              className={`${A.ArrowBtn}`}
               src={LeftArrowActive}
               alt="left"
               onClick={prevMonth}
-              disabled={false}
             />
-            <A.MonthText>{`${calMonth + 1}월`}</A.MonthText>
-            <A.ArrowBtn
+            <span className={A.MonthText}>{`${calMonth + 1}월`}</span>
+            <img
+              className={`${A.ArrowBtn} ${
+                isCurrentMonth ? A.ArrowBtnDisabled : ''
+              }`}
               style={{ transform: 'rotate(180deg)' }}
               src={LeftArrowActive}
               alt="right"
               onClick={nextMonth}
-              disabled={isCurrentMonth}
             />
-          </A.MonthRow>
+          </div>
 
-          <A.TotalRow>
-            <A.TotalSpent>
-              {comma(usedAmt)}원
-              <span>
-                <span className="slash"> / </span>
+          <div className={A.TotalRow}>
+            <p className={A.TotalSpent}>
+              {comma(usedAmt)}원{' '}
+              <span className={A.TotalSub}>
+                <span className={A.TotalSlash}> / </span>
                 {comma(totalBudgetAmt)}원
               </span>
-            </A.TotalSpent>
-            <A.EditBtn
+            </p>
+            <img
+              className={A.EditBtn}
               src={pencilIcon}
               alt="edit"
               onClick={() =>
@@ -365,35 +375,52 @@ const Money = () => {
                 })
               }
             />
-          </A.TotalRow>
+          </div>
 
-          <A.BudgetCardWrapper>
-            <A.Summary>
+          <div className={A.BudgetCardWrapper}>
+            <div className={A.Summary}>
               {usedAmt > 0 ? (
-                <A.SummaryP>
+                <p className={A.SummaryP}>
                   한 달 예산 {comma(totalBudgetAmt)}원 중{' '}
-                  <span>{comma(usedAmt)}원 </span>
+                  <span className={A.SummaryStrong}>{comma(usedAmt)}원 </span>
                   사용했어요!
-                </A.SummaryP>
+                </p>
               ) : (
-                <A.SummaryP>한 달 예산을 등록해주세요!</A.SummaryP>
+                <p className={A.SummaryP}>한 달 예산을 등록해주세요!</p>
               )}
 
-              <A.BarWrapper>
-                <A.Bar>
-                  <A.Fill
+              <div className={A.BarWrapper}>
+                <div className={A.Bar}>
+                  <div
+                    className={A.Fill}
                     style={{
                       width: `${fillPercent}%`,
                       transition: 'width .4s ease',
                     }}
                   />
-                </A.Bar>
+                </div>
 
-                <A.Below $fillPercent={fillPercent}>
-                  <span className="used-amount">
-                    <img src={starIcon} alt="star" />
-                    <span>{comma(usedAmt)}원</span>
+                <div className={A.Below}>
+                  <span
+                    className={A.UsedAmountWrap}
+                    style={{
+                      left: `${Math.min(Math.max(fillPercent, 0), 100)}%`,
+                    }}
+                  >
+                    <img
+                      className={A.UsedAmountStar}
+                      src={starIcon}
+                      alt="star"
+                    />
+                    <span
+                      style={{
+                        visibility: fillPercent === 0 ? 'hidden' : 'visible',
+                      }}
+                    >
+                      {comma(usedAmt)}원
+                    </span>
                   </span>
+
                   <span
                     style={{
                       position: 'absolute',
@@ -403,46 +430,52 @@ const Money = () => {
                   >
                     {comma(totalBudgetAmt)}원
                   </span>
-                </A.Below>
-              </A.BarWrapper>
-            </A.Summary>
-          </A.BudgetCardWrapper>
-        </A.TopContainer>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
 
-        <A.TabMenu>
-          <A.TabItemMenu>
-            {TAB_LIST.map((t) => (
-              <A.TabItem
-                key={t}
-                $active={activeTab === t}
-                onClick={() => setActiveTab(t)}
-              >
-                {t}
-              </A.TabItem>
-            ))}
-          </A.TabItemMenu>
-        </A.TabMenu>
+        {/* Tabs */}
+        <nav className={A.TabMenu}>
+          <div className={A.TabItemMenu}>
+            {TAB_LIST.map((t) => {
+              const isActive = activeTab === t;
+              return (
+                <button
+                  key={t}
+                  className={A.TabItem}
+                  onClick={() => setActiveTab(t)}
+                >
+                  {t}
+                  {isActive && <span className={A.TabUnderline} />}
+                </button>
+              );
+            })}
+          </div>
+        </nav>
 
-        <A.ContentArea>
+        <div className={A.ContentArea}>
           {activeTab === '일일' && (
             <>
-              <A.ButtonContainer>
-                <A.PlusBtn
+              <div className={A.ButtonContainer}>
+                <img
                   onClick={() => navigate('/add-day')}
+                  className={A.PlusBtn}
                   src={plusIcon}
                   alt="plus"
                 />
 
                 {(monthlyData?.pages?.[0]?.result?.monthlyHistory?.length ??
                   0) > 0 && (
-                  <A.DeleteToggleBtn
+                  <img
+                    className={A.DeleteToggleBtn(deleteMode)}
                     src={minusIcon}
                     alt="minus"
-                    $active={deleteMode}
                     onClick={() => setDeleteMode((v) => !v)}
                   />
                 )}
-              </A.ButtonContainer>
+              </div>
 
               {(monthlyData?.pages?.[0]?.result?.monthlyHistory?.length ?? 0) >
               0 ? (
@@ -453,15 +486,24 @@ const Money = () => {
                     const wd = WEEKDAY[dateObj.getDay()];
 
                     return (
-                      <A.Section key={day.date}>
-                        <A.DateRow>
-                          <span className="date">{`${dayNum} ${wd}`}</span>
-                        </A.DateRow>
+                      <section key={day.date} className={A.Section}>
+                        <div className={A.DateRow}>
+                          <span
+                            className={A.DateText}
+                          >{`${dayNum} ${wd}`}</span>
+                        </div>
 
                         {day.items.map((item) => (
-                          <A.ItemRow key={item.consumptionRecordId}>
-                            <A.ItemRowLeft>
-                              <A.Dot $hide={deleteMode}>
+                          <div
+                            key={item.consumptionRecordId}
+                            className={A.ItemRow}
+                          >
+                            <div className={A.ItemRowLeft}>
+                              <span
+                                className={`${A.DotBase} ${
+                                  deleteMode ? 'hidden' : 'flex'
+                                }`}
+                              >
                                 {item.categoryName === '[고정비]' ||
                                 item.categoryName === '고정비' ? (
                                   <img src={fixedCostImage} alt="고정비" />
@@ -473,17 +515,18 @@ const Money = () => {
                                 ) : (
                                   item.categoryName
                                 )}
-                              </A.Dot>
+                              </span>
                               <span className="memo">{item.content}</span>
-                            </A.ItemRowLeft>
+                            </div>
 
-                            <A.ItemRowRight>
+                            <div className={A.ItemRowRight}>
                               <span className="amount">
                                 {comma(item.amount)}원
                               </span>
 
                               {deleteMode && (
-                                <A.DeleteBtn
+                                <img
+                                  className={A.DeleteBtn}
                                   src={closeIcon}
                                   alt="delete"
                                   onClick={() =>
@@ -491,18 +534,22 @@ const Money = () => {
                                   }
                                 />
                               )}
-                            </A.ItemRowRight>
-                          </A.ItemRow>
+                            </div>
+                          </div>
                         ))}
-                      </A.Section>
+                      </section>
                     );
                   }),
                 )
               ) : (
-                <A.EmptyBox>
-                  <A.EmptyCircle src={emptyImage} alt="비어 있음" />
-                  <A.EmptyText>등록된 소비 내역이 없어요.</A.EmptyText>
-                </A.EmptyBox>
+                <div className={A.EmptyBox}>
+                  <img
+                    className={A.EmptyCircle}
+                    src={emptyImage}
+                    alt="비어 있음"
+                  />
+                  <p className={A.EmptyText}>등록된 소비 내역이 없어요.</p>
+                </div>
               )}
 
               {hasNextPage && <div ref={loadMoreRef} style={{ height: 40 }} />}
@@ -511,16 +558,19 @@ const Money = () => {
 
           {activeTab === '달력' && (
             <>
-              <A.CalendarWrap>
-                <A.WeekRow>
+              <div className={A.CalendarWrap}>
+                <div className={A.WeekRow}>
                   {WEEKDAY.map((w) => (
-                    <A.WeekCell key={w}>{w}</A.WeekCell>
+                    <div className={A.WeekCell} key={w}>
+                      {w}
+                    </div>
                   ))}
-                </A.WeekRow>
+                </div>
 
-                <A.DayGrid>
+                <div className={A.DayGrid}>
                   {calendarCells.map((d, i) => {
-                    if (!d) return <A.DayCell key={`empty-${i}`} />;
+                    if (!d)
+                      return <div className={A.DayCell} key={`empty-${i}`} />;
 
                     const dateStr = `${calYear}-${String(calMonth + 1).padStart(
                       2,
@@ -531,30 +581,33 @@ const Money = () => {
                     const isSelected = selectedDate === dateStr;
 
                     return (
-                      <A.DayCell key={dateStr}>
-                        <A.DayNumButton
-                          $selected={isSelected}
+                      <div className={A.DayCell} key={dateStr}>
+                        <button
+                          className={A.DayNumButton(isSelected)}
                           onClick={() => toggleDate(dateStr)}
                         >
                           {d}
-                        </A.DayNumButton>
+                        </button>
 
                         {daySpent !== 0 && (
-                          <A.SpendPill $minus={true}>
+                          <span className={A.SpendPill(true)}>
                             -{comma(Math.abs(daySpent))}
-                          </A.SpendPill>
+                          </span>
                         )}
 
                         {(i + 1) % 7 === 0 &&
-                          i + 1 !== calendarCells.length && <A.WeekDivider />}
-                      </A.DayCell>
+                          i + 1 !== calendarCells.length && (
+                            <div className={A.WeekDivider} />
+                          )}
+                      </div>
                     );
                   })}
-                </A.DayGrid>
-              </A.CalendarWrap>
+                </div>
+              </div>
 
               {selectedDate && (
-                <A.CalListSection
+                <section
+                  className={A.CalListSection}
                   style={{
                     transform: `translateY(${dragOffset}px)`,
                     transition: anim ? 'transform 0.25s ease' : 'none',
@@ -563,17 +616,20 @@ const Money = () => {
                   onPointerMove={onDragMove}
                   onPointerUp={onDragEnd}
                 >
-                  <A.SheetHandle />
+                  <div className={A.SheetHandle} />
 
-                  <A.CalDateTitle>
+                  <h3 className={A.CalDateTitle}>
                     {new Date(selectedDate).getDate()}{' '}
                     {WEEKDAY[new Date(selectedDate).getDay()]}
-                  </A.CalDateTitle>
+                  </h3>
 
                   {selectedList.length ? (
                     selectedList.map((item) => (
-                      <A.CalItemRow key={item.consumptionRecordId}>
-                        <A.CalDot>
+                      <div
+                        className={A.CalItemRow}
+                        key={item.consumptionRecordId}
+                      >
+                        <span className={A.CalDot}>
                           {item.categoryName === '[고정비]' ||
                           item.categoryName === '고정비' ? (
                             <img src={fixedCostImage} alt="고정비" />
@@ -585,62 +641,69 @@ const Money = () => {
                           ) : (
                             item.categoryName
                           )}
-                        </A.CalDot>
-                        <span className="memo">{item.content}</span>
-                        <span className="amount">{comma(item.amount)}원</span>
-                      </A.CalItemRow>
+                        </span>
+                        <span className={A.CalMemo}>{item.content}</span>
+                        <span className={A.CalAmount}>
+                          {comma(item.amount)}원
+                        </span>
+                      </div>
                     ))
                   ) : (
-                    <A.EmptyBoxSmall>
+                    <div className={A.EmptyBoxSmall}>
                       해당 날짜에 기록이 없어요.
-                    </A.EmptyBoxSmall>
+                    </div>
                   )}
 
-                  <A.FloatingPlus onClick={() => navigate('/record')}>
+                  <button
+                    className={A.FloatingPlus}
+                    onClick={() => navigate('/record')}
+                  >
                     <img src={plusCircle} alt="add" />
-                  </A.FloatingPlus>
-                </A.CalListSection>
+                  </button>
+                </section>
               )}
             </>
           )}
 
           {activeTab === '고정비' && (
             <>
-              <A.ButtonContainer>
-                <A.PlusBtn
+              <div className={A.ButtonContainer}>
+                <img
                   onClick={() => navigate('/fixed-cost')}
+                  className={A.PlusBtn}
                   src={plusIcon}
                   alt="plus"
                 />
 
                 {fixedItems.length > 0 && (
-                  <A.DeleteToggleBtn
+                  <img
+                    className={A.DeleteToggleBtn(fixedDel)}
                     src={minusIcon}
                     alt="minus"
-                    $active={fixedDel}
                     onClick={() => setFixedDel((v) => !v)}
                   />
                 )}
-              </A.ButtonContainer>
+              </div>
 
               {fixedItems.length ? (
-                <A.Section2>
+                <section className={A.Section2}>
                   {fixedItems.map((e) => (
-                    <A.ItemRow key={e.fixedConsumptionId}>
-                      <A.ItemRowLeft>
-                        <A.Dot>
+                    <div key={e.fixedConsumptionId} className={A.ItemRow}>
+                      <div className={A.ItemRowLeft}>
+                        <span className={`${A.DotBase} flex`}>
                           <img src={fixedCostImage} alt="fixed cost" />
-                        </A.Dot>
+                        </span>
                         <span className="memo">
                           {e.memo || e.categoryName || ''}
                         </span>
-                      </A.ItemRowLeft>
+                      </div>
 
-                      <A.ItemRowRight>
+                      <div className={A.ItemRowRight}>
                         <span className="amount">{comma(e.amount)}원</span>
 
                         {fixedDel && (
-                          <A.DeleteBtn
+                          <img
+                            className={A.DeleteBtn}
                             src={closeIcon}
                             alt="close"
                             onClick={() => deleteFixed(e.fixedConsumptionId)}
@@ -650,39 +713,44 @@ const Money = () => {
                             }}
                           />
                         )}
-                      </A.ItemRowRight>
-                    </A.ItemRow>
+                      </div>
+                    </div>
                   ))}
 
                   {hasNextFixed && (
                     <div ref={fixedLoadMoreRef} style={{ height: 40 }} />
                   )}
-                </A.Section2>
+                </section>
               ) : (
-                <A.EmptyBox>
-                  <A.EmptyCircle src={emptyImage} alt="비어 있음" />
-                  <A.EmptyText>등록된 고정비가 없어요.</A.EmptyText>
-                </A.EmptyBox>
+                <div className={A.EmptyBox}>
+                  <img
+                    className={A.EmptyCircle}
+                    src={emptyImage}
+                    alt="비어 있음"
+                  />
+                  <p className={A.EmptyText}>등록된 고정비가 없어요.</p>
+                </div>
               )}
             </>
           )}
 
           {activeTab === '소비 루틴' && (
             <>
-              <A.ButtonContainer>
-                <A.PlusBtn
+              <div className={A.ButtonContainer}>
+                <img
                   onClick={() =>
                     navigate('/money-routine', {
                       state: { budgetId: totalData?.result?.budgetId ?? 0 },
                     })
                   }
+                  className={A.PlusBtn}
                   src={plusIcon}
                   alt="plus"
                 />
-              </A.ButtonContainer>
+              </div>
 
               {routines.length ? (
-                <A.RoutineCardList>
+                <div className={A.RoutineCardList}>
                   {routines.map((r) => {
                     const date = new Date(r.createDate);
                     const dateStr = `${date.getFullYear()} • ${String(
@@ -695,8 +763,9 @@ const Money = () => {
                     const imgUrl = resolveRoutineImageUrl(r);
 
                     return (
-                      <A.RoutineWideCard
+                      <button
                         key={r.routineId}
+                        className={A.RoutineWideCard}
                         onClick={() =>
                           navigate(`/myroutine/${r.routineId}`, {
                             state: { from: 'money' },
@@ -704,7 +773,8 @@ const Money = () => {
                         }
                         style={{ overflow: 'visible' }}
                       >
-                        <A.PreviewBox
+                        <div
+                          className={A.PreviewBox}
                           style={
                             imgUrl
                               ? {
@@ -718,17 +788,21 @@ const Money = () => {
                           }
                         />
 
-                        <A.RoutineContent style={{ overflow: 'visible' }}>
-                          <A.DateLine>{dateStr}</A.DateLine>
+                        <div
+                          className={A.RoutineContent}
+                          style={{ overflow: 'visible' }}
+                        >
+                          <div className={A.DateLine}>{dateStr}</div>
 
-                          <A.TitleRow
+                          <div
+                            className={A.TitleRow}
                             style={{
                               overflow: 'visible',
                               alignItems: 'flex-start',
                             }}
                           >
                             <h3
-                              className="title"
+                              className={A.TitleH3}
                               style={{
                                 margin: 0,
                                 lineHeight: 1.35,
@@ -739,44 +813,54 @@ const Money = () => {
                             >
                               {r.routineName}
                             </h3>
-                            <A.ArrowIcon src={arrowIconImg} alt="arrow" />
-                          </A.TitleRow>
+                            <img
+                              className={A.ArrowIcon}
+                              src={arrowIconImg}
+                              alt="arrow"
+                            />
+                          </div>
 
-                          <A.TagsRow>
+                          <div className={A.TagsRow}>
                             {(r.hashtags ?? []).map((t) => {
                               const tag = t.startsWith('#') ? t : `#${t}`;
                               return (
-                                <span className="tag" key={tag}>
+                                <span className={A.Tag} key={tag}>
                                   {tag}
                                 </span>
                               );
                             })}
-                          </A.TagsRow>
+                          </div>
 
-                          <A.UserRow>
-                            <A.Avatar />
-                            <span className="nick">{r.nickname || '라인'}</span>
-                          </A.UserRow>
-                        </A.RoutineContent>
-                      </A.RoutineWideCard>
+                          <div className={A.UserRow}>
+                            <div className={A.Avatar} />
+                            <span className={A.Nick}>
+                              {r.nickname || '라인'}
+                            </span>
+                          </div>
+                        </div>
+                      </button>
                     );
                   })}
 
                   {hasNextRoutines && (
                     <div ref={routineLoadMoreRef} style={{ height: 40 }} />
                   )}
-                </A.RoutineCardList>
+                </div>
               ) : (
-                <A.EmptyBox>
-                  <A.EmptyCircle src={emptyImage} alt="비어 있음" />
-                  <A.EmptyText>등록된 소비 루틴이 없어요.</A.EmptyText>
-                </A.EmptyBox>
+                <div className={A.EmptyBox}>
+                  <img
+                    className={A.EmptyCircle}
+                    src={emptyImage}
+                    alt="비어 있음"
+                  />
+                  <p className={A.EmptyText}>등록된 소비 루틴이 없어요.</p>
+                </div>
               )}
             </>
           )}
-        </A.ContentArea>
-      </A.MainContainer>
-    </A.Container>
+        </div>
+      </main>
+    </div>
   );
 };
 

--- a/src/styles/budget/money.styles.tsx
+++ b/src/styles/budget/money.styles.tsx
@@ -1,681 +1,139 @@
-import React from 'react';
-
-const cx = (...arr: Array<string | false | null | undefined>) =>
-  arr.filter(Boolean).join(' ');
-
-export const Container: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'pt-[8.4rem] pb-[13rem] w-full h-screen bg-[var(--color-B1)] flex flex-col items-center',
-      p.className,
-    )}
-  />
-);
-
-export const MainContainer: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => <div {...p} className={cx('overflow-y-auto w-full', p.className)} />;
-
-export const TopContainer: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => <div {...p} className={cx('w-full px-[2.4rem]', p.className)} />;
-
-export const GreetingCard: React.FC<React.HTMLAttributes<HTMLElement>> = (
-  p,
-) => (
-  <section
-    {...p}
-    style={{
-      ...(p.style || {}),
-      background:
-        'linear-gradient(135deg, var(--color-subColor3) 0%, #4be3a5 100%)',
-    }}
-    className={cx(
-      'w-full h-[11rem] rounded-[1.5rem] flex gap-[2.2rem] items-center mb-[2.4rem]',
-      p.className,
-    )}
-  />
-);
-
-export const GreetText: React.FC<React.HTMLAttributes<HTMLParagraphElement>> = (
-  p,
-) => (
-  <>
-    <style>{`
-      .greet-text span { font-weight: 500; }
-    `}</style>
-    <p
-      {...p}
-      className={cx(
-        'greet-text ml-[3.9rem] text-[var(--color-white)] text-[2rem] font-[700] leading-[2.8rem]',
-        p.className,
-      )}
-    />
-  </>
-);
-
-export const MiniCard: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
-  p,
-) => <img {...p} className={cx('w-[8.4rem] h-[9.2rem]', p.className)} />;
-
-export const MonthRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx('flex w-full items-center gap-[0.4rem]', p.className)}
-  />
-);
-
-type ArrowBtnProps = React.ImgHTMLAttributes<HTMLImageElement> & {
-  disabled?: boolean;
-};
-export const ArrowBtn: React.FC<ArrowBtnProps> = ({ disabled, ...p }) => (
-  <img
-    {...p}
-    className={cx(
-      'w-[2.4rem] h-[2.4rem] cursor-pointer',
-      disabled && 'opacity-30 pointer-events-none',
-      p.className,
-    )}
-  />
-);
-
-export const MonthText: React.FC<React.HTMLAttributes<HTMLSpanElement>> = (
-  p,
-) => (
-  <span
-    {...p}
-    className={cx(
-      'text-[1.6rem] font-[500] text-[var(--color-G1)]',
-      p.className,
-    )}
-  />
-);
-
-export const TotalRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'my-[0.6rem] w-full flex items-center gap-[0.5rem]',
-      p.className,
-    )}
-  />
-);
-
-export const TotalSpent: React.FC<
-  React.HTMLAttributes<HTMLParagraphElement>
-> = (p) => (
-  <>
-    <style>{`
-      .total-spent span { font-weight: 500; font-size: 1.8rem; color: var(--color-G4); }
-      .total-spent .slash { font-size: 1.6rem; }
-    `}</style>
-    <p
-      {...p}
-      className={cx(
-        'total-spent text-[2.4rem] font-[700] text-[var(--color-G1)]',
-        p.className,
-      )}
-    />
-  </>
-);
-
-export const EditBtn: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
-  p,
-) => (
-  <img
-    {...p}
-    className={cx(
-      'w-[1.8rem] h-[1.8rem] cursor-pointer mt-[0.2rem]',
-      p.className,
-    )}
-  />
-);
-
-export const BudgetCardWrapper: React.FC<
-  React.HTMLAttributes<HTMLDivElement>
-> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'w-full h-[10.1rem] my-[0.6rem] mb-[2.4rem] px-[1.5rem] bg-[var(--color-white)] rounded-[1.5rem] shadow-[0_0_1rem_0_#0000000d] flex items-center justify-center',
-      p.className,
-    )}
-  />
-);
-
-export const Summary: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'flex flex-col w-full items-center gap-[0.8rem]',
-      p.className,
-    )}
-  />
-);
-
-export const SummaryP: React.FC<React.HTMLAttributes<HTMLParagraphElement>> = (
-  p,
-) => (
-  <>
-    <style>{`
-      .summary-p span { font-weight: 700; color: var(--color-subColor3); }
-    `}</style>
-    <p
-      {...p}
-      className={cx(
-        'summary-p w-full text-[1.4rem] font-[500] text-[var(--color-G3)]',
-        p.className,
-      )}
-    />
-  </>
-);
-
-export const BarWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'w-full relative h-[3.9rem] flex justify-center items-center',
-      p.className,
-    )}
-  />
-);
-
-export const Bar: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'w-[98%] h-[0.6rem] bg-[var(--color-G8)] rounded-[1rem] overflow-hidden',
-      p.className,
-    )}
-  />
-);
-
-export const Fill: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'h-full bg-[var(--color-mainColor1)] rounded-[1rem] transition-[width] duration-200 ease-linear',
-      p.className,
-    )}
-  />
-);
-
-type BelowProps = React.HTMLAttributes<HTMLDivElement> & {
-  $fillPercent: number;
-};
-export const Below: React.FC<BelowProps> = ({ $fillPercent, ...p }) => {
-  const safe = Math.min(Math.max($fillPercent, 0), 100);
-  return (
-    <>
-      <style>{`
-        .below .used-amount{
-          position:absolute; bottom:-0.6rem; display:flex; flex-direction:column; align-items:center;
-          left: var(--fill-left); transform: translateX(-50%);
-        }
-        .below .used-amount img{ width:1.6rem; height:1.5rem; margin-bottom:1.4rem; }
-        .below .used-amount span{ visibility: var(--used-vis); }
-      `}</style>
-      <div
-        {...p}
-        className={cx(
-          'below absolute left-[1%] w-[98%] bottom-0 text-[1.1rem] font-light text-[var(--color-G5)] pointer-events-none',
-          p.className,
-        )}
-        style={{
-          ...(p.style || {}),
-          // @ts-expect-error CSS var
-          '--fill-left': `${safe}%`,
-          '--used-vis': safe === 0 ? 'hidden' : 'visible',
-        }}
-      />
-    </>
-  );
-};
-
-/* ---------------- Tabs ---------------- */
-
-export const TabMenu: React.FC<React.HTMLAttributes<HTMLElement>> = (p) => (
-  <nav
-    {...p}
-    className={cx(
-      'w-full h-[4.3rem] flex justify-center rounded-t-[1.5rem] border-b border-[var(--color-G7)] shadow-[0_0_1rem_0_#0000000d]',
-      p.className,
-    )}
-  />
-);
-
-export const TabItemMenu: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx('flex gap-[5.6rem] justify-between pt-[1rem]', p.className)}
-  />
-);
-
-type TabItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  $active: boolean;
-};
-export const TabItem: React.FC<TabItemProps> = ({
-  $active,
-  children,
-  ...p
-}) => (
-  <button
-    {...p}
-    className={cx(
-      'text-[1.5rem] font-[500] relative pb-[0.6rem] cursor-pointer',
-      p.className,
-    )}
-  >
-    {children}
-    {$active && (
-      <span className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[4.4rem] h-[0.4rem] bg-[var(--color-mainColor1)] rounded-[1rem]" />
-    )}
-  </button>
-);
-
-/* ---------------- Content ---------------- */
-
-export const ContentArea: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'bg-[var(--color-white)] h-full w-full relative pt-[2.71rem]',
-      p.className,
-    )}
-  />
-);
-
-export const ButtonContainer: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'w-full flex justify-end pr-[2.4rem] gap-[1.6rem]',
-      p.className,
-    )}
-  />
-);
-
-export const PlusBtn: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
-  p,
-) => (
-  <img
-    {...p}
-    className={cx('w-[2.4rem] h-[2.4rem] cursor-pointer', p.className)}
-  />
-);
-
-type DeleteToggleBtnProps = React.ImgHTMLAttributes<HTMLImageElement> & {
-  $active?: boolean;
-};
-export const DeleteToggleBtn: React.FC<DeleteToggleBtnProps> = ({
-  $active,
-  className,
-  ...rest
-}) => (
-  <img
-    {...rest}
-    className={cx(
-      'w-[2.4rem] h-[2.4rem] cursor-pointer',
-      $active && 'opacity-100',
-      !$active && 'opacity-40',
-      className,
-    )}
-  />
-);
-
-export const Section: React.FC<React.HTMLAttributes<HTMLElement>> = (p) => (
-  <section
-    {...p}
-    className={cx(
-      'py-[2rem] pr-[2.4rem] pl-[2.4rem] pb-[2.4rem] border-b border-[var(--color-G7)] last:border-b-0',
-      p.className,
-    )}
-  />
-);
-
-export const Section2: React.FC<React.HTMLAttributes<HTMLElement>> = (p) => (
-  <section
-    {...p}
-    className={cx(
-      'py-[2rem] px-[2.4rem] flex flex-col gap-[1.8rem] border-b border-[var(--color-G7)] last:border-b-0',
-      p.className,
-    )}
-  />
-);
-
-export const DateRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <>
-    <style>{`.date-row .date{ font-size:1.4rem; font-weight:500; color: var(--color-G1); }`}</style>
-    <div {...p} className={cx('date-row w-full mb-[1.9rem]', p.className)} />
-  </>
-);
-
-export const ItemRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'w-full h-[4rem] flex items-center justify-between mb-[1.8rem] text-[1.5rem] font-[500] text-[var(--color-G1)] last:mb-0',
-      p.className,
-    )}
-  />
-);
-
-export const ItemRowLeft: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div {...p} className={cx('flex items-center gap-[1.2rem]', p.className)} />
-);
-
-export const ItemRowRight: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div {...p} className={cx('flex items-center gap-[2.8rem]', p.className)} />
-);
-
-export const DeleteBtn: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
-  p,
-) => (
-  <img
-    {...p}
-    className={cx('cursor-pointer w-[2.4rem] h-[2.4rem]', p.className)}
-  />
-);
-
-type DotProps = React.HTMLAttributes<HTMLSpanElement> & { $hide?: boolean };
-export const Dot: React.FC<DotProps> = ({ $hide, ...p }) => (
-  <span
-    {...p}
-    className={cx(
-      'w-[4rem] h-[4rem] rounded-full',
-      !$hide && 'flex',
-      $hide && 'hidden',
-      p.className,
-    )}
-  >
-    {p.children}
-  </span>
-);
-
-export const EmptyBox: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'my-[12.3rem] mb-[25.9rem] flex flex-col items-center justify-center text-center gap-[2rem]',
-      p.className,
-    )}
-  />
-);
-
-export const EmptyCircle: React.FC<
-  React.ImgHTMLAttributes<HTMLImageElement>
-> = (p) => (
-  <img
-    {...p}
-    className={cx('w-[13.822rem] h-[13rem] mr-[1rem]', p.className)}
-  />
-);
-
-export const EmptyText: React.FC<React.HTMLAttributes<HTMLParagraphElement>> = (
-  p,
-) => (
-  <p
-    {...p}
-    className={cx(
-      'text-[1.6rem] text-[var(--color-G1)] font-[500]',
-      p.className,
-    )}
-  />
-);
-
-export const RoutineCardList: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'my-[1.8rem] mx-[2.4rem] flex flex-col gap-[1rem]',
-      p.className,
-    )}
-  />
-);
-
-export const RoutineWideCard: React.FC<
-  React.ButtonHTMLAttributes<HTMLButtonElement>
-> = (p) => (
-  <button
-    {...p}
-    className={cx(
-      'w-full flex h-[10.6rem] px-[1.5rem] gap-[1.1rem] rounded-[1.5rem] bg-[var(--color-white)] shadow-[0_0_1rem_0_#0000000d] cursor-pointer justify-start items-center',
-      p.className,
-    )}
-  />
-);
-
-export const PreviewBox: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'w-[8.4rem] h-[8.4rem] flex-none rounded-[1rem] bg-[var(--color-G8)] opacity-80 shadow-[0_0_1rem_0_#0000000d]',
-      p.className,
-    )}
-  />
-);
-
-export const RoutineContent: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => <div {...p} className={cx('flex flex-col w-full', p.className)} />;
-
-export const DateLine: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'text-[0.8rem] font-light text-[var(--color-G3)] text-left',
-      p.className,
-    )}
-  />
-);
-
-export const TitleRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <>
-    <style>{`.title-row .title{ font-size:1.5rem; font-weight:500; color:var(--color-G1); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }`}</style>
-    <div
-      {...p}
-      className={cx('title-row flex items-center justify-between', p.className)}
-    />
-  </>
-);
-
-export const ArrowIcon: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = (
-  p,
-) => <img {...p} className={cx('w-[0.8rem] h-auto', p.className)} />;
-
-export const TagsRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <>
-    <style>{`.tags-row .tag{ font-size:1.1rem; font-weight:300; color:var(--color-G4); }`}</style>
-    <div {...p} className={cx('tags-row flex gap-[0.6rem]', p.className)} />
-  </>
-);
-
-export const UserRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <>
-    <style>{`.user-row .nick{ font-size:1.1rem; font-weight:500; color:var(--color-G1); }`}</style>
-    <div
-      {...p}
-      className={cx(
-        'user-row flex items-center mt-[2.1rem] gap-[0.6rem]',
-        p.className,
-      )}
-    />
-  </>
-);
-
-export const Avatar: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'w-[1.4rem] h-[1.4rem] rounded-full bg-[var(--color-G7)]',
-      p.className,
-    )}
-  />
-);
-
-export const CalendarWrap: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => <div {...p} className={cx('px-[2.4rem]', p.className)} />;
-
-export const WeekRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'w-full grid grid-cols-7 text-center text-[1.4rem] font-[500] text-[var(--color-G1)]',
-      p.className,
-    )}
-  />
-);
-
-export const WeekCell: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div {...p} className={cx('mb-[2rem]', p.className)} />
-);
-
-export const DayGrid: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx('w-full grid grid-cols-7 gap-y-[1.6rem]', p.className)}
-  />
-);
-
-export const WeekDivider: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => <div {...p} className={cx('', p.className)} />;
-
-export const DayCell: React.FC<React.HTMLAttributes<HTMLDivElement>> = (p) => (
-  <div
-    {...p}
-    className={cx(
-      'flex flex-col items-center h-[7.6rem] relative',
-      p.className,
-    )}
-  />
-);
-
-type DayNumProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  $selected: boolean;
-};
-export const DayNumButton: React.FC<DayNumProps> = ({ $selected, ...p }) => (
-  <button
-    {...p}
-    className={cx(
-      'w-[2.7rem] h-[2.7rem] rounded-full text-[1.4rem] font-[500] grid place-items-center p-0',
-      $selected
-        ? 'border-[0.05rem] border-[var(--color-mainColor1)] bg-[var(--color-subColor5)] text-[var(--color-mainColor1)]'
-        : 'border-none bg-transparent text-[var(--color-G1)]',
-      p.className,
-    )}
-  />
-);
-
-type SpendPillProps = React.HTMLAttributes<HTMLSpanElement> & {
-  $minus: boolean;
-};
-export const SpendPill: React.FC<SpendPillProps> = ({ $minus, ...p }) => (
-  <span
-    {...p}
-    className={cx(
-      'mt-[0.5rem] px-[6px] h-[1.6rem] rounded-[0.5rem] text-[1rem] leading-none inline-flex items-center whitespace-nowrap text-[var(--color-subColor1)]',
-      $minus ? 'bg-[var(--color-subColor5)]' : 'bg-transparent',
-      p.className,
-    )}
-  />
-);
-
-export const CalListSection: React.FC<React.HTMLAttributes<HTMLElement>> = (
-  p,
-) => (
-  <section
-    {...p}
-    className={cx(
-      'p-[16px] bg-[#f0fff9] rounded-t-[16px] mt-[-300px] pb-[190px]',
-      p.className,
-    )}
-  />
-);
-
-export const CalDateTitle: React.FC<
-  React.HTMLAttributes<HTMLHeadingElement>
-> = (p) => (
-  <h3 {...p} className={cx('text-[16px] font-[700] mb-[12px]', p.className)} />
-);
-
-export const CalItemRow: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <>
-    <style>{`.cal-item .memo{flex:1; font-size:14px;} .cal-item .amount{font-size:14px; font-weight:600;}`}</style>
-    <div
-      {...p}
-      className={cx(
-        'cal-item flex items-center gap-[12px] py-[12px] border-b border-[var(--color-G8)]',
-        p.className,
-      )}
-    />
-  </>
-);
-
-export const CalDot: React.FC<React.HTMLAttributes<HTMLSpanElement>> = (p) => (
-  <span
-    {...p}
-    className={cx(
-      'flex-none w-[32px] h-[32px] rounded-full bg-[#f6f6f6] overflow-hidden flex items-center justify-center',
-      p.className,
-    )}
-  />
-);
-
-export const EmptyBoxSmall: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'pt-[12px] pb-[24px] text-center text-[var(--color-G4)] text-[13px]',
-      p.className,
-    )}
-  />
-);
-
-export const SheetHandle: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
-  p,
-) => (
-  <div
-    {...p}
-    className={cx(
-      'w-[36px] h-[4px] rounded-[2px] bg-[var(--color-G4)] mx-auto mb-[12px]',
-      p.className,
-    )}
-  />
-);
-
-export const FloatingPlus: React.FC<
-  React.ButtonHTMLAttributes<HTMLButtonElement>
-> = (p) => (
-  <button
-    {...p}
-    className={cx(
-      'absolute right-[18px] bottom-[24px] w-[52px] h-[52px] rounded-full bg-transparent border-0 p-0 cursor-pointer',
-      p.className,
-    )}
-  />
-);
+export const Container =
+  'pt-[8.4rem] pb-[13rem] w-full h-screen bg-[var(--color-B1)] flex flex-col items-center';
+
+export const MainContainer = 'overflow-y-auto w-full';
+export const TopContainer = 'w-full px-[2.4rem]';
+
+export const GreetingCard =
+  'w-full h-[11rem] rounded-[1.5rem] flex gap-[2.2rem] items-center mb-[2.4rem]';
+export const GreetText =
+  'ml-[3.9rem] text-[var(--color-white)] text-[2rem] font-[700] leading-[2.8rem]';
+export const MiniCard = 'w-[8.4rem] h-[9.2rem]';
+export const MonthRow = 'flex w-full items-center gap-[0.4rem]';
+export const ArrowBtn = 'w-[2.4rem] h-[2.4rem] cursor-pointer';
+export const ArrowBtnDisabled = 'opacity-30 pointer-events-none';
+export const MonthText = 'text-[1.6rem] font-[500] text-[var(--color-G1)]';
+
+export const TotalRow = 'my-[0.6rem] w-full flex items-center gap-[0.5rem]';
+export const TotalSpent = 'text-[2.4rem] font-[700] text-[var(--color-G1)]';
+export const TotalSlash = 'text-[1.6rem]';
+export const TotalSub = 'font-[500] text-[1.8rem] text-[var(--color-G4)]';
+export const EditBtn = 'w-[1.8rem] h-[1.8rem] cursor-pointer mt-[0.2rem]';
+
+export const BudgetCardWrapper =
+  'w-full h-[10.1rem] my-[0.6rem] mb-[2.4rem] px-[1.5rem] bg-[var(--color-white)] rounded-[1.5rem] shadow-[0_0_1rem_0_#0000000d] flex items-center justify-center';
+
+export const Summary = 'flex flex-col w-full items-center gap-[0.8rem]';
+export const SummaryP =
+  'w-full text-[1.4rem] font-[500] text-[var(--color-G3)]';
+export const SummaryStrong = 'font-[700] text-[var(--color-subColor3)]';
+
+export const BarWrapper =
+  'w-full relative h-[3.9rem] flex justify-center items-center';
+export const Bar =
+  'w-[98%] h-[0.6rem] bg-[var(--color-G8)] rounded-[1rem] overflow-hidden';
+export const Fill =
+  'h-full bg-[var(--color-mainColor1)] rounded-[1rem] transition-[width]';
+
+export const Below =
+  'absolute left-[1%] w-[98%] bottom-0 text-[1.1rem] font-light text-[var(--color-G5)] pointer-events-none';
+export const UsedAmountWrap =
+  'absolute -translate-x-1/2 bottom-[-0.6rem] flex flex-col items-center';
+export const UsedAmountStar = 'w-[1.6rem] h-[1.5rem] mb-[1.4rem]';
+
+export const TabMenu =
+  'w-full h-[4.3rem] flex justify-center rounded-t-[1.5rem] border-b border-[var(--color-G7)] shadow-[0_0_1rem_0_#0000000d]';
+export const TabItemMenu = 'flex gap-[5.6rem] justify-between pt-[1rem]';
+export const TabItem =
+  'text-[1.5rem] font-[500] relative pb-[0.6rem] cursor-pointer';
+export const TabUnderline =
+  'absolute bottom-0 left-1/2 -translate-x-1/2 w-[4.4rem] h-[0.4rem] bg-[var(--color-mainColor1)] rounded-[1rem]';
+
+export const ContentArea =
+  'bg-[var(--color-white)] h-full w-full relative pt-[2.71rem]';
+
+export const ButtonContainer =
+  'w-full flex justify-end pr-[2.4rem] gap-[1.6rem]';
+export const PlusBtn = 'w-[2.4rem] h-[2.4rem] cursor-pointer';
+export const DeleteToggleBtn = (active: boolean) =>
+  `w-[2.4rem] h-[2.4rem] cursor-pointer ${
+    active ? 'text-[var(--color-mainColor1)]' : 'text-[var(--color-G3)]'
+  }`;
+
+export const Section =
+  'py-[2rem] pr-[2.4rem] pl-[2.4rem] pb-[2.4rem] border-b border-[var(--color-G7)] last:border-b-0';
+export const Section2 =
+  'py-[2rem] px-[2.4rem] flex flex-col gap-[1.8rem] border-b border-[var(--color-G7)] last:border-b-0';
+
+export const DateRow = 'w-full mb-[1.9rem]';
+export const DateText = 'text-[1.4rem] font-[500] text-[var(--color-G1)]';
+
+export const ItemRow =
+  'w-full h-[4rem] flex items-center justify-between mb-[1.8rem] text-[1.5rem] font-[500] text-[var(--color-G1)] last:mb-0';
+export const ItemRowLeft = 'flex items-center gap-[1.2rem]';
+export const ItemRowRight = 'flex items-center gap-[2.8rem]';
+export const DeleteBtn = 'cursor-pointer w-[2.4rem] h-[2.4rem]';
+
+export const DotBase = 'w-[4rem] h-[4rem] rounded-full';
+
+export const EmptyBox =
+  'my-[12.3rem] mb-[25.9rem] flex flex-col items-center justify-center text-center gap-[2rem]';
+export const EmptyCircle = 'w-[13.822rem] h-[13rem] mr-[1rem]';
+export const EmptyText = 'text-[1.6rem] text-[var(--color-G1)] font-[500]';
+
+export const RoutineCardList =
+  'my-[1.8rem] mx-[2.4rem] flex flex-col gap-[1rem]';
+export const RoutineWideCard =
+  'w-full flex h-[10.6rem] px-[1.5rem] gap-[1.1rem] rounded-[1.5rem] bg-[var(--color-white)] shadow-[0_0_1rem_0_#0000000d] cursor-pointer justify-start items-center';
+export const PreviewBox =
+  'w-[8.4rem] h-[8.4rem] flex-none rounded-[1rem] bg-[var(--color-G8)] opacity-80 shadow-[0_0_1rem_0_#0000000d]';
+export const RoutineContent = 'flex flex-col w-full';
+export const DateLine =
+  'text-[0.8rem] font-light text-[var(--color-G3)] text-left';
+export const TitleRow = 'flex items-center justify-between';
+export const TitleH3 =
+  'text-[1.5rem] font-[500] text-[var(--color-G1)] overflow-hidden text-ellipsis whitespace-nowrap';
+export const ArrowIcon = 'w-[0.8rem] h-auto';
+export const TagsRow = 'flex gap-[0.6rem]';
+export const Tag = 'text-[1.1rem] font-[300] text-[var(--color-G4)]';
+export const UserRow = 'flex items-center mt-[2.1rem] gap-[0.6rem]';
+export const Avatar = 'w-[1.4rem] h-[1.4rem] rounded-full bg-[var(--color-G7)]';
+export const Nick = 'text-[1.1rem] font-[500] text-[var(--color-G1)]';
+
+export const CalendarWrap = 'px-[2.4rem]';
+export const WeekRow =
+  'w-full grid grid-cols-7 text-center text-[1.4rem] font-[500] text-[var(--color-G1)]';
+export const WeekCell = 'mb-[2rem]';
+export const DayGrid = 'w-full grid grid-cols-7 gap-y-[1.6rem]';
+export const WeekDivider = '';
+export const DayCell = 'flex flex-col items-center h-[7.6rem] relative';
+
+export const DayNumButton = (selected: boolean) =>
+  [
+    'w-[2.7rem] h-[2.7rem] rounded-full text-[1.4rem] font-[500] grid place-items-center p-0',
+    selected
+      ? 'border-[0.05rem] border-[var(--color-mainColor1)] bg-[var(--color-subColor5)] text-[var(--color-mainColor1)]'
+      : 'border-none bg-transparent text-[var(--color-G1)]',
+  ].join(' ');
+
+export const SpendPill = (minus: boolean) =>
+  [
+    'mt-[0.5rem] px-[6px] h-[1.6rem] rounded-[0.5rem] text-[1rem] leading-none inline-flex items-center whitespace-nowrap text-[var(--color-subColor1)]',
+    minus ? 'bg-[var(--color-subColor5)]' : 'bg-transparent',
+  ].join(' ');
+
+export const CalListSection =
+  'p-[16px] bg-[#f0fff9] rounded-t-[16px] mt-[-300px] pb-[190px]';
+export const CalDateTitle = 'text-[16px] font-[700] mb-[12px]';
+export const CalItemRow =
+  'flex items-center gap-[12px] py-[12px] border-b border-[var(--color-G8)]';
+export const CalMemo = 'flex-1 text-[14px]';
+export const CalAmount = 'text-[14px] font-[600]';
+export const CalDot =
+  'flex-none w-[32px] h-[32px] rounded-full bg-[#f6f6f6] overflow-hidden flex items-center justify-center';
+export const EmptyBoxSmall =
+  'pt-[12px] pb-[24px] text-center text-[var(--color-G4)] text-[13px]';
+export const SheetHandle =
+  'w-[36px] h-[4px] rounded-[2px] bg-[var(--color-G4)] mx-auto mb-[12px]';
+export const FloatingPlus =
+  'absolute right-[18px] bottom-[24px] w-[52px] h-[52px] rounded-full bg-transparent border-0 p-0 cursor-pointer';


### PR DESCRIPTION
<!--
    PR 제목은 커밋 메시지와 동일한 형식으로 작성하기 ex) ✨ feat: 로그인 페이지 UI 구현
    PR 날릴 때 Assignees는 자기 자신 선택
    PR 날릴 때 Reviewers는 다른 팀원 선택해주기(최소 두명 이상)
-->

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #127 

## 🔑 작업 내용

<!-- 내가 작업한 내용에 대해 작성해주세요! -->
가계부 UI 리팩토링

## 📷 스크린샷

<!-- 작업물에 대한 스크린샷을 첨부해주세요 -->
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/f552fa1a-7779-490f-9db2-b905cc2c5d92" />


## 🌐 공유 사항 to 리뷰어

<!— 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있다면 적어주세요 —>
<!— 논의해야 할 부분이 있다면 적어주세요 —>

## 🚨 이슈 사항

<!— 이슈가 발생하는 부분이 있다면 적어주세요 —>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Refreshed Money page UI with clearer header, tabs, budget summary, progress bar, daily history, fixed costs, routines, and calendar.
  - Active tab underline and improved calendar day selection/pills.
  - Enhanced progress bar with used-amount indicator and star; clearer empty states and updated category icons.

- Bug Fixes
  - More reliable tab restoration when returning to the page.
  - Right arrow visibly disabled on the current month; navigation behavior clarified.
  - Clearer delete-mode feedback on items.

- Refactor
  - Migrated to class-based styling for consistency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->