### PR TITLE
🐛 Fix: 사진, 메모 섹션 필수 표시 제거 및 ModalBox 위치 조정

### DIFF
--- a/src/components/home/record/imageSection.tsx
+++ b/src/components/home/record/imageSection.tsx
@@ -11,7 +11,7 @@ interface Props {
 const ImageSection = ({ imageUrl, isDisabled, onChange }: Props) => {
   return (
     <div className={S.ImageSection}>
-      <Title>사진</Title>
+      <Title showStar={isDisabled}>사진</Title>
       <div className={S.ImageInputWrapper(isDisabled)}>
         <label htmlFor="imageUpload" className={S.ImageLabel}>
           {imageUrl ? (

--- a/src/components/home/record/memoSection.tsx
+++ b/src/components/home/record/memoSection.tsx
@@ -18,7 +18,7 @@ const MemoSection = ({
 }: Props) => {
   return (
     <div className={S.MemoSection}>
-      <Title>메모</Title>
+      <Title showStar={isDisabled}>메모</Title>
       <textarea
         value={value}
         onChange={onChange}

--- a/src/components/home/record/title.tsx
+++ b/src/components/home/record/title.tsx
@@ -3,13 +3,14 @@ import star from '../../../assets/images/home/record/star.png';
 
 interface Props {
   children: React.ReactNode;
+  showStar?: boolean;
 }
 
-const Title = ({ children }: Props) => {
+const Title = ({ children, showStar = true }: Props) => {
   return (
     <div className={S.Title}>
       {children}
-      <img className={S.StarImg} src={star} alt="star" />
+      {showStar && <img className={S.StarImg} src={star} alt="star" />}
     </div>
   );
 };

--- a/src/styles/home/modal.style.ts
+++ b/src/styles/home/modal.style.ts
@@ -2,7 +2,7 @@
 export const ModalBackdrop =
   'fixed top-0 left-0 w-screen h-screen bg-[#11111199] flex items-center justify-center z-[999]';
 export const ModalBox =
-  'absolute bg-white pt-[1.9rem] pb-[1.9rem] px-[1.6rem] rounded-[1.5rem] w-[14.8rem] min-h-[13.8rem] overflow-y-auto top-[52.1rem] left-[calc(50%+8.2rem)] -translate-x-1/2 z-[1001]';
+  'absolute bg-white pt-[1.9rem] pb-[1.9rem] px-[1.6rem] rounded-[1.5rem] w-[14.8rem] min-h-[13.8rem] overflow-y-auto top-[50.7rem] left-[calc(50%+8.2rem)] -translate-x-1/2 z-[1001]';
 export const ModalList = 'w-[11.6rem] h-[1.6rem]';
 export const ModalItem = 'flex items-center justify-between mb-[1.2rem]';
 export const LeftGroup = 'flex items-center gap-[0.7rem]';


### PR DESCRIPTION

## 🚀 관련 이슈



- close #132 

## 🔑 작업 내용

- 사진, 메모 섹션 필수 표시 제거
- ModalBox 위치 조정

## 📷 스크린샷
<img width="1980" height="1369" alt="스크린샷(71)" src="https://github.com/user-attachments/assets/98ba3e98-09a0-43c1-af21-7e35656f5bfa" />



## 🌐 공유 사항 to 리뷰어



## 🚨 이슈 사항




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Titles in Image and Memo sections now conditionally display a star indicator based on the section’s state (shown when enabled, hidden when disabled).

* **Style**
  * Adjusted modal position upward by approximately 1.4rem for improved on-screen placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->