### PR TITLE
✨ Feat: 소비기록 가계부에만 등록하는 경우 사진 영역 비활성화 및 public 토글에 따른 업로드/초기화 처리

### DIFF
--- a/src/components/home/record/imageSection.tsx
+++ b/src/components/home/record/imageSection.tsx
@@ -21,11 +21,13 @@ const ImageSection = ({ imageUrl, isDisabled, onChange }: Props) => {
           )}
         </label>
         <input
+          key={!isDisabled ? 'disabled' : 'enabled'}
           id="imageUpload"
           type="file"
           accept="image/*"
           onChange={onChange}
           className={S.ImageInput}
+          disabled={!isDisabled}
         />
       </div>
     </div>

--- a/src/pages/home/record.tsx
+++ b/src/pages/home/record.tsx
@@ -102,9 +102,17 @@ function record() {
             onSelectCategory={(category) =>
               setFormData((prev) => ({ ...prev, categoryName: category }))
             }
-            onToggle={() =>
-              setFormData((prev) => ({ ...prev, isPublic: !prev.isPublic }))
-            }
+            onToggle={() => {
+              setFormData((prev) => {
+                const newIsPublic = !prev.isPublic;
+                return {
+                  ...prev,
+                  isPublic: newIsPublic,
+                  ...(newIsPublic ? {} : { imageUrl: '' }),
+                };
+              });
+              setFile(null);
+            }}
           />
 
           <div className={S.RecordSection}>


### PR DESCRIPTION

## 🚀 관련 이슈

<!-- 이슈 번호를 작성하여 종료시켜주세요 -->

- close #138 

## 🔑 작업 내용

가계부에만 등록하는 경우 사진 영역 비활성화 및 public 토글에 따른 업로드/초기화 처리

## 📷 스크린샷



## 🌐 공유 사항 to 리뷰어

소비기록 등록 시 문제 있으면 알려주세요~

## 🚨 이슈 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image upload field now correctly reflects its disabled state.
  * Switching visibility to Private clears any selected image and its URL to prevent unintended sharing.
  * Selected file is consistently cleared after any visibility toggle to avoid stale uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->