### PR TITLE
👽 Feat: 타인의 소비루틴 반영 API 연결

### DIFF
--- a/src/components/auth/login/kakao/kakao.tsx
+++ b/src/components/auth/login/kakao/kakao.tsx
@@ -12,6 +12,7 @@ const Kakao = () => {
   const handleLogin = () => {
     window.Kakao.Auth.authorize({
       redirectUri: getRedirectUri(),
+      throughTalk: false,
     });
   };
 

--- a/src/hooks/money/addday/useCategoryQuery.tsx
+++ b/src/hooks/money/addday/useCategoryQuery.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { API } from '../../../apis/axios';
+import type { CategoryReponse } from '../../../types/money/addday/addday';
+
+export const fetchCategory = async (): Promise<CategoryReponse> => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  const { data } = await API.get<CategoryReponse>(
+    `/api/consumptionrecord/categories`,
+    {
+      headers: accessToken
+        ? { Authorization: `Bearer ${accessToken}` }
+        : undefined,
+    },
+  );
+  return data;
+};
+
+export const useCategoryQuery = () => {
+  return useQuery({
+    queryKey: ['categories'],
+    queryFn: fetchCategory,
+  });
+};

--- a/src/hooks/money/money/useFixedCostQuery.tsx
+++ b/src/hooks/money/money/useFixedCostQuery.tsx
@@ -4,12 +4,18 @@ import { API } from '../../../apis/axios';
 import type { FixedCostResponse } from '../../../types/money/money/fixedCost';
 
 const fetchFixedCostList = async (
+  year: number,
+  month: number,
   cursorId?: number,
 ): Promise<FixedCostResponse> => {
   const { data } = await API.get<FixedCostResponse>(
     '/api/house-holds/fixed-consumptions/list',
     {
-      params: cursorId ? { cursorId } : {},
+      params: {
+        year,
+        month,
+        ...(cursorId ? { cursorId } : {}),
+      },
       headers: {
         Authorization: `Bearer ${localStorage.getItem('accessToken') || ''}`,
       },
@@ -18,17 +24,17 @@ const fetchFixedCostList = async (
   return data;
 };
 
-export const useFixedCostQuery = () => {
+export const useFixedCostQuery = (year: number, month: number) => {
   return useInfiniteQuery<
     FixedCostResponse,
     Error,
     InfiniteData<FixedCostResponse, number | undefined>,
-    [string],
+    [string, number, number],
     number | undefined
   >({
-    queryKey: ['fixedCostList'],
+    queryKey: ['fixedCostList', year, month],
     queryFn: ({ pageParam }) =>
-      fetchFixedCostList(pageParam as number | undefined),
+      fetchFixedCostList(year, month, pageParam as number | undefined),
     getNextPageParam: (lastPage) =>
       lastPage.result.hasNext
         ? (lastPage.result.nextCursorId ?? undefined)

--- a/src/hooks/money/registration/useRoutineDetailQuery.tsx
+++ b/src/hooks/money/registration/useRoutineDetailQuery.tsx
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { API } from '../../../apis/axios';
+import type { RoutineDetailResponse } from '../../../types/money/registration/routineDetail';
+
+export const fetchRoutineDetail = async (
+  routineId: number,
+): Promise<RoutineDetailResponse> => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  const { data } = await API.get<RoutineDetailResponse>(
+    `/api/house-holds/routines/list/${routineId}/apply-info`,
+    {
+      headers: accessToken
+        ? { Authorization: `Bearer ${accessToken}` }
+        : undefined,
+    },
+  );
+  return data;
+};
+
+export const useRoutineDetailQuery = (routineId?: number) => {
+  return useQuery({
+    queryKey: ['routineDetail', routineId],
+    queryFn: () => fetchRoutineDetail(routineId!),
+    enabled: !!routineId,
+  });
+};

--- a/src/hooks/money/registration/useRoutineMutation.tsx
+++ b/src/hooks/money/registration/useRoutineMutation.tsx
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query';
+import { API } from '../../../apis/axios';
+import type { RoutinePayload } from '../../../types/money/registration/routine';
+
+export const useRoutineMutation = () => {
+  return useMutation({
+    mutationFn: async ({
+      routineId,
+      data,
+    }: {
+      routineId: number;
+      data: RoutinePayload;
+    }) => {
+      const accessToken = localStorage.getItem('accessToken');
+
+      const res = await API.patch(
+        `/api/house-holds/routines/list/${routineId}/apply`,
+        data,
+        {
+          params: { routineId },
+          headers: accessToken
+            ? { Authorization: `Bearer ${accessToken}` }
+            : undefined,
+        },
+      );
+      return res.data;
+    },
+  });
+};

--- a/src/pages/money/addday.tsx
+++ b/src/pages/money/addday.tsx
@@ -4,11 +4,10 @@ import Header from '../../components/header/header';
 import pencilIcon from '../../assets/images/budget/pencil.png';
 import closeIcon from '../../assets/images/budget/Close.png';
 import circleCloseIcon from '../../assets/images/budget/CircleClose.png';
+import { useCategoryQuery } from '../../hooks/money/addday/useCategoryQuery';
 import { useDailyMutation as createDailyConsumption } from '../../hooks/money/addday/useDailyMutation';
 
 import * as A from '../../styles/budget/addday.styles';
-
-const CATEGORIES = ['배달/외식', '교통', '패션/쇼핑', '카페', '기타'] as const;
 
 const comma = (v: string | number) =>
   String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
@@ -53,6 +52,12 @@ const AddDay = () => {
   const [rawAmt, setRawAmt] = useState('');
 
   const dateInputRef = useRef<HTMLInputElement>(null);
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  const { data } = useCategoryQuery();
+
+  const categories = data?.result ?? [];
+
   const ensureDateStr = () => {
     if (!dateStr) setDateStr(toLocalDt(new Date()));
   };
@@ -67,11 +72,9 @@ const AddDay = () => {
     ensureDateStr();
     const el = dateInputRef.current as DateTimeInput | null;
     if (!el) return;
-    if (typeof el.showPicker === 'function') {
+
+    if (!isMobile && typeof el.showPicker === 'function') {
       el.showPicker();
-    } else {
-      el.focus();
-      el.click();
     }
   };
 
@@ -139,23 +142,23 @@ const AddDay = () => {
               카테고리 선택<span>*</span>
             </A.Label>
 
-            <div style={{ overflowX: 'auto', paddingBottom: 4 }}>
+            <div style={{ overflowX: 'auto', paddingBottom: '0.4rem' }}>
               <A.CatBox
                 style={{
                   display: 'flex',
                   flexWrap: 'nowrap',
-                  gap: '8px',
+                  gap: '0.8rem',
                   width: 'max-content',
                 }}
               >
-                {CATEGORIES.map((c) => (
+                {categories.map((c) => (
                   <A.CatBtn
-                    key={c}
-                    $on={c === category}
-                    onClick={() => setCategory(c)}
+                    key={c.categoryName}
+                    $on={c.categoryName === category}
+                    onClick={() => setCategory(c.categoryName)}
                     style={{ flex: '0 0 auto', whiteSpace: 'nowrap' }}
                   >
-                    {c}
+                    {c.categoryName}
                   </A.CatBtn>
                 ))}
               </A.CatBox>
@@ -214,7 +217,7 @@ const AddDay = () => {
                   width: '100%',
                   height: '100%',
                   opacity: 0,
-                  pointerEvents: 'none',
+                  pointerEvents: isMobile ? 'auto' : 'none',
                 }}
                 value={toNativeValue(dateStr)}
                 onChange={onNativePick}

--- a/src/pages/money/money.tsx
+++ b/src/pages/money/money.tsx
@@ -156,7 +156,7 @@ const Money = () => {
     fetchNextPage: fetchNextFixed,
     hasNextPage: hasNextFixed,
     isFetchingNextPage: isFetchingNextFixed,
-  } = useFixedCostQuery();
+  } = useFixedCostQuery(targetYear, targetMonth);
 
   const fixedItems = useMemo(
     () => fixedListData?.pages.flatMap((p) => p.result.fixedConsumptions) ?? [],

--- a/src/pages/money/registration.tsx
+++ b/src/pages/money/registration.tsx
@@ -77,6 +77,7 @@ const BudgetRegister = () => {
 
   useEffect(() => {
     if (!source) return;
+    // console.log(source);
 
     const {
       totalBudget,
@@ -98,7 +99,7 @@ const BudgetRegister = () => {
       routineCategoryBudgets?.map((c) => c.categoryName) ?? [];
     const routineAmounts = routineCategoryBudgets?.map((c) => c.amount) ?? [];
 
-    if (!localStorage.getItem('monthBudget')) {
+    if (!localStorage.getItem('monthBudget') || routineId) {
       localStorage.setItem('monthBudget', String(totalBudget));
       localStorage.setItem('categoryBudgets', JSON.stringify(defaultArr));
       localStorage.setItem('customCategories', JSON.stringify(customNames));
@@ -119,7 +120,7 @@ const BudgetRegister = () => {
       setRoutineCategories(routineNames);
       setRoutineCatBudget(routineAmounts);
     }
-  }, [source]);
+  }, [source, routineId]);
 
   useEffect(() => {
     if (!budgetId) {

--- a/src/pages/money/registration.tsx
+++ b/src/pages/money/registration.tsx
@@ -8,8 +8,11 @@ import circleCloseIcon from '../../assets/images/budget/CircleClose.png';
 import plusCircle from '../../assets/images/budget/Plus-2.png';
 import minusIcon from '../../assets/images/budget/minus.png';
 import { useBudgetMutation } from '../../hooks/money/registration/useBudgetsMutation';
+import { useRoutineMutation } from '../../hooks/money/registration/useRoutineMutation';
 import { useBudgetDetailQuery } from '../../hooks/money/registration/useBudgetDetailQuery';
+import { useRoutineDetailQuery } from '../../hooks/money/registration/useRoutineDetailQuery';
 import * as R from '../../styles/budget/registration.styles';
+import type { RegistrationState } from '../../types/money/registration/registration';
 
 const CATEGORIES = ['배달/외식', '패션/쇼핑', '교통', '카페', '기타'];
 
@@ -17,17 +20,40 @@ const BudgetRegister = () => {
   const navigate = useNavigate();
 
   const { state } = useLocation() as {
-    state?: { year?: number; month?: number; budgetId?: number };
+    state?: RegistrationState;
   };
-  const year = state?.year ?? new Date().getFullYear();
-  const month = state?.month ?? new Date().getMonth() + 1;
-  const budgetId = state?.budgetId;
 
+  const [year, setYear] = useState<number>(new Date().getFullYear());
+  const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
+  const [budgetId, setBudgetId] = useState<number | null>(null);
+  const [routineId, setRoutineId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const syncStateWithStorage = <T extends string | number>(
+      key: string,
+      value: T | undefined,
+      setter: (val: T) => void,
+      parser: (s: string) => T,
+    ) => {
+      if (value !== undefined && value !== null) {
+        localStorage.setItem(key, String(value));
+        setter(value);
+      } else {
+        const saved = localStorage.getItem(key);
+        if (saved) setter(parser(saved));
+      }
+    };
+
+    syncStateWithStorage('year', state?.year, setYear, Number);
+    syncStateWithStorage('month', state?.month, setMonth, Number);
+    syncStateWithStorage('budgetId', state?.budgetId, setBudgetId, Number);
+    syncStateWithStorage('routineId', state?.routineId, setRoutineId, Number);
+  }, [state?.year, state?.month, state?.budgetId, state?.routineId]);
+
+  const { data: budgetDetail } = useBudgetDetailQuery(budgetId!);
+  const { data: routineDetail } = useRoutineDetailQuery(routineId!);
   const budgetMutation = useBudgetMutation();
-  const { data: budgetDetail } = useBudgetDetailQuery(budgetId);
-  console.log(budgetId);
-  console.log(budgetDetail);
-  //
+  const routineMutation = useRoutineMutation();
 
   const [monthBudget, setMonthBudget] = useState(0);
   const [catBudget, setCatBudget] = useState<number[]>(Array(5).fill(0));
@@ -44,31 +70,35 @@ const BudgetRegister = () => {
   const [raw, setRaw] = useState('');
   const [targetIdx, setTargetIdx] = useState<-1 | number>(-1);
   const [targetIsCustom, setTargetIsCustom] = useState(false);
+  const [targetIsRoutine, setTargetIsRoutine] = useState(false);
 
-  // 인서 추가
+  const source =
+    budgetDetail?.result ?? (!budgetId ? routineDetail?.result : null);
+
   useEffect(() => {
-    if (budgetDetail?.result) {
-      const {
-        totalBudget,
-        defaultCategoryBudgets,
-        customCategoryBudgets,
-        routineCategoryBudgets,
-      } = budgetDetail.result;
+    if (!source) return;
 
-      const defaultArr = CATEGORIES.map(
-        (name) =>
-          defaultCategoryBudgets.find((c) => c.categoryName === name)?.amount ??
-          0,
-      );
+    const {
+      totalBudget,
+      defaultCategoryBudgets = [],
+      customCategoryBudgets = [],
+      routineCategoryBudgets = [],
+    } = source;
 
-      const customNames =
-        customCategoryBudgets?.map((c) => c.categoryName) ?? [];
-      const customAmounts = customCategoryBudgets?.map((c) => c.amount) ?? [];
+    const defaultArr = CATEGORIES.map(
+      (name) =>
+        defaultCategoryBudgets.find((c) => c.categoryName === name)?.amount ??
+        0,
+    );
 
-      const routineNames =
-        routineCategoryBudgets?.map((c) => c.categoryName) ?? [];
-      const routineAmounts = routineCategoryBudgets?.map((c) => c.amount) ?? [];
+    const customNames = customCategoryBudgets?.map((c) => c.categoryName) ?? [];
+    const customAmounts = customCategoryBudgets?.map((c) => c.amount) ?? [];
 
+    const routineNames =
+      routineCategoryBudgets?.map((c) => c.categoryName) ?? [];
+    const routineAmounts = routineCategoryBudgets?.map((c) => c.amount) ?? [];
+
+    if (!localStorage.getItem('monthBudget')) {
       localStorage.setItem('monthBudget', String(totalBudget));
       localStorage.setItem('categoryBudgets', JSON.stringify(defaultArr));
       localStorage.setItem('customCategories', JSON.stringify(customNames));
@@ -89,7 +119,7 @@ const BudgetRegister = () => {
       setRoutineCategories(routineNames);
       setRoutineCatBudget(routineAmounts);
     }
-  }, [budgetDetail]);
+  }, [source]);
 
   useEffect(() => {
     if (!budgetId) {
@@ -138,9 +168,10 @@ const BudgetRegister = () => {
       k === 'back' ? prev.slice(0, -1) : (prev + k).replace(/^0+(?=\d)/, ''),
     );
 
-  const openModal = (idx: number, isCustom = false) => {
+  const openModal = (idx: number, isCustom = false, isRoutine = false) => {
     setTargetIdx(idx);
     setTargetIsCustom(isCustom);
+    setTargetIsRoutine(isRoutine);
     setModalOpen(true);
   };
 
@@ -151,32 +182,58 @@ const BudgetRegister = () => {
     if (targetIdx === -1) {
       setMonthBudget(n);
       localStorage.setItem('monthBudget', String(n));
-    } else if (!targetIsCustom) {
+    } else if (!targetIsCustom && !targetIsRoutine) {
       setCatBudget((prev) => {
         const next = [...prev];
         next[targetIdx] = n;
         localStorage.setItem('categoryBudgets', JSON.stringify(next));
         return next;
       });
-    } else {
+    } else if (targetIsCustom) {
       setMyCatBudget((prev) => {
         const next = [...prev];
         next[targetIdx] = n;
         localStorage.setItem('customCategoryBudgets', JSON.stringify(next));
         return next;
       });
+    } else if (targetIsRoutine) {
+      setRoutineCatBudget((prev) => {
+        const next = [...prev];
+        next[targetIdx] = n;
+        localStorage.setItem('routineCategoryBudgets', JSON.stringify(next));
+        return next;
+      });
     }
+
     setModalOpen(false);
     setRaw('');
   };
 
-  const deleteCategory = (idx: number) => {
-    setMyCategories((prev) => {
-      const next = prev.filter((_, i) => i !== idx);
-      localStorage.setItem('customCategories', JSON.stringify(next));
-      return next;
-    });
-    setMyCatBudget((prev) => prev.filter((_, i) => i !== idx));
+  const deleteCategory = (idx: number, type: 'custom' | 'routine') => {
+    if (type === 'custom') {
+      setMyCategories((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        localStorage.setItem('customCategories', JSON.stringify(next));
+        return next;
+      });
+      setMyCatBudget((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        localStorage.setItem('customCategoryBudgets', JSON.stringify(next));
+        return next;
+      });
+    }
+    if (type === 'routine') {
+      setRoutineCategories((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        localStorage.setItem('routineCategories', JSON.stringify(next));
+        return next;
+      });
+      setRoutineCatBudget((prev) => {
+        const next = prev.filter((_, i) => i !== idx);
+        localStorage.setItem('routineCategoryBudgets', JSON.stringify(next));
+        return next;
+      });
+    }
   };
 
   const totalDefault = catBudget.reduce((a, b) => a + b, 0);
@@ -187,6 +244,7 @@ const BudgetRegister = () => {
     monthBudget === totalDefault + totalCustom + totalRoutine;
 
   const handleConfirm = () => {
+    // console.log('routineId', routineId);
     if (!canConfirm) return;
 
     const defaultCategoryBudgets = CATEGORIES.map((name, idx) => ({
@@ -201,38 +259,49 @@ const BudgetRegister = () => {
       categoryType: 'CUSTOM' as const,
     }));
 
-    budgetMutation.mutate(
-      {
-        year,
-        month,
-        data: {
-          totalBudget: monthBudget,
-          defaultCategoryBudgets,
-          customCategoryBudgets:
-            customCategoryBudgets.length > 0
-              ? customCategoryBudgets
-              : undefined,
-        },
-      },
-      {
-        onSuccess: (data) => {
-          alert('한달 예산이 등록되었습니다.');
-          // console.log(data);
-          localStorage.removeItem('monthBudget');
-          localStorage.removeItem('categoryBudgets');
-          localStorage.removeItem('customCategories');
-          localStorage.removeItem('customCategoryBudgets');
-          localStorage.removeItem('routineCategories');
-          localStorage.removeItem('routineCategoryBudgets');
+    const routineCategoryBudgets = routineCategories.map((name, idx) => ({
+      categoryName: name,
+      amount: routineCatBudget[idx],
+      categoryType: 'ROUTINE_CATEGORY' as const,
+    }));
 
-          navigate('/money', {
-            replace: true,
-            state: { total: data.result.totalBudget },
-          });
-          console.log(data.totalBudget);
-        },
-      },
-    );
+    const payload = {
+      totalBudget: monthBudget,
+      defaultCategoryBudgets,
+      customCategoryBudgets:
+        customCategoryBudgets.length > 0 ? customCategoryBudgets : undefined,
+      routineCategoryBudgets:
+        routineCategoryBudgets.length > 0 ? routineCategoryBudgets : undefined,
+    };
+
+    const onSuccess = (data: any) => {
+      alert(
+        routineId
+          ? '소비 루틴 예산이 반영되었습니다.'
+          : '한달 예산이 등록되었습니다.',
+      );
+      localStorage.removeItem('monthBudget');
+      localStorage.removeItem('categoryBudgets');
+      localStorage.removeItem('customCategories');
+      localStorage.removeItem('customCategoryBudgets');
+      localStorage.removeItem('routineCategories');
+      localStorage.removeItem('routineCategoryBudgets');
+      localStorage.removeItem('year');
+      localStorage.removeItem('month');
+      localStorage.removeItem('budgetId');
+      localStorage.removeItem('routineId');
+
+      navigate('/money', {
+        replace: true,
+        state: { total: data.result.totalBudget },
+      });
+    };
+
+    if (routineId) {
+      routineMutation.mutate({ routineId, data: payload }, { onSuccess });
+    } else {
+      budgetMutation.mutate({ year, month, data: payload }, { onSuccess });
+    }
   };
 
   return (
@@ -248,7 +317,7 @@ const BudgetRegister = () => {
               className={R.IconBtn}
               src={pencilIcon}
               alt="edit"
-              onClick={() => openModal(-1)}
+              onClick={() => openModal(-1, false, false)}
             />
           </div>
         </section>
@@ -271,7 +340,7 @@ const BudgetRegister = () => {
               <li
                 className={R.CatLi(editMode)}
                 key={c}
-                onClick={() => editMode && openModal(i, false)}
+                onClick={() => editMode && openModal(i, false, false)}
               >
                 {c}
 
@@ -319,7 +388,7 @@ const BudgetRegister = () => {
                     className={R.CatLi(myEditMode || myDeleteMode)}
                     key={name}
                     onClick={() =>
-                      myEditMode && !myDeleteMode && openModal(i, true)
+                      myEditMode && !myDeleteMode && openModal(i, true, false)
                     }
                   >
                     {name}
@@ -340,7 +409,7 @@ const BudgetRegister = () => {
                           className={R.DeleteBtn}
                           src={closeIcon}
                           alt="delete"
-                          onClick={() => deleteCategory(i)}
+                          onClick={() => deleteCategory(i, 'custom')}
                         />
                       )}
                     </div>
@@ -388,7 +457,7 @@ const BudgetRegister = () => {
                     onClick={() =>
                       routineEditMode &&
                       !routineDeleteMode &&
-                      openModal(i, true)
+                      openModal(i, false, true)
                     }
                   >
                     {name}
@@ -409,7 +478,7 @@ const BudgetRegister = () => {
                           className={R.DeleteBtn}
                           src={closeIcon}
                           alt="delete"
-                          onClick={() => deleteCategory(i)}
+                          onClick={() => deleteCategory(i, 'routine')}
                         />
                       )}
                     </div>

--- a/src/types/money/addday/addday.ts
+++ b/src/types/money/addday/addday.ts
@@ -11,3 +11,12 @@ export interface CreateConsumptionResponse {
   code: string;
   message: string;
 }
+
+export interface CategoryReponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    categoryName: string;
+  }[];
+}

--- a/src/types/money/registration/registration.ts
+++ b/src/types/money/registration/registration.ts
@@ -1,0 +1,6 @@
+export type RegistrationState = {
+  year?: number;
+  month?: number;
+  budgetId?: number;
+  routineId?: number;
+};

--- a/src/types/money/registration/routine.ts
+++ b/src/types/money/registration/routine.ts
@@ -1,0 +1,12 @@
+export interface CategoryRoutine {
+  categoryName: string;
+  amount: number;
+  categoryType: 'DEFAULT' | 'CUSTOM' | 'ROUTINE_CATEGORY';
+}
+
+export interface RoutinePayload {
+  totalBudget: number;
+  defaultCategoryBudgets: CategoryRoutine[];
+  customCategoryBudgets?: CategoryRoutine[];
+  routineCategoryBudgets?: CategoryRoutine[];
+}

--- a/src/types/money/registration/routineDetail.ts
+++ b/src/types/money/registration/routineDetail.ts
@@ -1,0 +1,13 @@
+import type { CategoryRoutine } from './routine';
+
+export interface RoutineDetailResponse {
+  isSuccess: boolean;
+  code: string;
+  message: string;
+  result: {
+    totalBudget: number;
+    defaultCategoryBudgets: CategoryRoutine[];
+    customCategoryBudgets: CategoryRoutine[];
+    routineCategoryBudgets: CategoryRoutine[];
+  };
+}


### PR DESCRIPTION
## 🚀 관련 이슈

## 🔑 작업 내용
- 타인의 소비루틴 반영 API 연결 완료

## 📷 스크린샷
**- 소비루틴 조회 및 수정**
<img width="1512" height="982" alt="스크린샷 2025-08-21 오전 1 24 02" src="https://github.com/user-attachments/assets/d416ccce-295c-4138-9ec8-6dc6c6a14599" />

**- 소비루틴 연결 완료 시**
<img width="1512" height="982" alt="스크린샷 2025-08-21 오전 1 23 52" src="https://github.com/user-attachments/assets/0ec7d069-1810-4060-a8ca-c1601f0d2c1b" />


## 🌐 공유 사항 to 리뷰어
- 헤더에 있는 뒤로가기 버튼과 관련하여 state 값 전달 등 오류가 많아서 가계부 담당자분 오류 잡아주시면 감사하겠습니다!

## 🚨 이슈 사항
다음과 같은 상황에서 문제가 생깁니다.
1. 타인 소비루틴 반영 전에, 직접 예산 등록을 합니다. -> 이때 카테고리도 추가함
2. 예산 등록 완료 후, 타인의 소비루틴을 반영합니다.
3. 타인의 소비루틴을 불러오는 과정에서, 직접 예산 등록 시 추가한 카테고리도 불러와지는데 가격은 0으로 뜸

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for routine-specific budgets: load routine details, edit/delete routine categories, and save routine changes with total budget.
  * Persist year, month, budget, and routine selections across sessions for a smoother return experience.
  * Dynamic category loading on Add Day replaces the previous hard-coded list.

* **Improvements**
  * Kakao login now prefers a web-based flow, reducing unexpected switches to the KakaoTalk app.
  * Date picker interaction improved for clearer mobile vs desktop behavior.
  * Fixed-cost views are now scoped to the selected year and month.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->