### PR TITLE
🐛 Fix: 타인 소비루틴 예산 반영 오류 해결

### DIFF
--- a/src/hooks/common/useClearBudgetStorage.tsx
+++ b/src/hooks/common/useClearBudgetStorage.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export function useClearBudgetStorage() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (
+      location.pathname !== '/budget-register' &&
+      location.pathname !== '/add-category'
+    ) {
+      localStorage.removeItem('monthBudget');
+      localStorage.removeItem('categoryBudgets');
+      localStorage.removeItem('customCategories');
+      localStorage.removeItem('customCategoryBudgets');
+      localStorage.removeItem('routineCategories');
+      localStorage.removeItem('routineCategoryBudgets');
+      localStorage.removeItem('totalRoutineBudget');
+      localStorage.removeItem('year');
+      localStorage.removeItem('month');
+      localStorage.removeItem('budgetId');
+      localStorage.removeItem('routineId');
+      localStorage.removeItem('budgetInitialized');
+    }
+  }, [location.pathname]);
+}

--- a/src/layouts/root-layout.tsx
+++ b/src/layouts/root-layout.tsx
@@ -1,10 +1,12 @@
 import { Outlet, useLocation } from 'react-router-dom';
 import Footer from '../components/footer/footer';
 import useAutoTokenRefresh from '../hooks/auth/token/useAutoTokenRefresh';
+import { useClearBudgetStorage } from '../hooks/common/useClearBudgetStorage';
 
 const RootLayout = () => {
   useAutoTokenRefresh();
   const location = useLocation();
+  useClearBudgetStorage();
   const currentPath = location.pathname;
 
   const showFooterPaths = ['/home', '/money', '/feed', '/mypage'];

--- a/src/pages/money/addcategory.tsx
+++ b/src/pages/money/addcategory.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import Header from '../../components/header/header';
 import CircleCloseIcon from '../../assets/images/budget/CircleClose.png';
@@ -11,6 +11,10 @@ type FromState = { state?: { from?: string; budgetId?: number } };
 const AddCategory = () => {
   const navigate = useNavigate();
   const location = useLocation() as FromState;
+
+  useEffect(() => {
+    localStorage.setItem('budgetInitialized', 'true');
+  }, []);
 
   const from = location?.state?.from || '/budget-register';
   const budgetId = location?.state?.budgetId ?? 0;

--- a/src/pages/money/addday.tsx
+++ b/src/pages/money/addday.tsx
@@ -75,6 +75,8 @@ const AddDay = () => {
 
     if (!isMobile && typeof el.showPicker === 'function') {
       el.showPicker();
+    } else {
+      el.click();
     }
   };
 

--- a/src/pages/money/fixedcost.tsx
+++ b/src/pages/money/fixedcost.tsx
@@ -105,13 +105,13 @@ const FixedCost = () => {
             <span className="ml-[0.2rem] text-[var(--color-M1)]">*</span>
           </p>
 
-          <div className="overflow-x-auto pb-[4px]">
+          <div className="overflow-x-auto pb-[0.4rem]">
             <div
               className={`${A.CatBox}`}
               style={{
                 display: 'flex',
                 flexWrap: 'nowrap',
-                gap: '8px',
+                gap: '0.8rem',
                 width: 'max-content',
               }}
             >

--- a/src/pages/money/money.tsx
+++ b/src/pages/money/money.tsx
@@ -50,11 +50,11 @@ const categoryImages: Record<string, string> = {
 };
 
 const tipByTopCategory: Record<string, string> = {
-  '배달/외식': '이 정도면 셰프를 모셔도 되겠어요!',
-  교통: '이 정도면 반쯤 전국일주 하셨네요!',
-  '패션/쇼핑': '이젠 뭘 샀는지 기억이 잘 안 나지 않나요?',
-  카페: '이 정도면 카페를 차리는 게 나을 것 같아요!',
-  기타: '돈이 들어오자마자 나가는 마술을 부리고 있나요?',
+  '배달/외식': '이 정도면 셰프를\n모셔도 되겠어요!',
+  교통: '이 정도면 반쯤\n전국일주 하셨네요!',
+  '패션/쇼핑': '이젠 뭘 샀는지\n기억이 잘 안 나지 않나요?',
+  카페: '이 정도면 카페를 차리는 게\n나을 것 같아요!',
+  기타: '돈이 들어오자마자 나가는\n마술을 부리고 있나요?',
 };
 
 type RoutineItemWithLegacyImage = RoutineListItem & {
@@ -166,6 +166,8 @@ const Money = () => {
     hasNextPage: hasNextFixed,
     isFetchingNextPage: isFetchingNextFixed,
   } = useFixedCostQuery(targetYear, targetMonth);
+
+  console.log('fixed', fixedListData);
 
   const fixedItems = useMemo(
     () => fixedListData?.pages.flatMap((p) => p.result.fixedConsumptions) ?? [],
@@ -437,7 +439,7 @@ const Money = () => {
                 'linear-gradient(135deg, var(--color-subColor3) 0%, #4be3a5 100%)',
               display: 'flex',
               alignItems: 'center',
-              gap: '12px',
+              gap: '1.2rem',
             }}
           >
             {showTopTip ? (
@@ -446,22 +448,22 @@ const Money = () => {
                   display: 'flex',
                   alignItems: 'center',
                   width: '100%',
-                  gap: 16,
-                  padding: '14px 20px 14px 32px',
+                  gap: '1.6rem',
+                  padding: '1.4rem 2rem 1.4rem 3.2rem',
                 }}
               >
                 <div
                   style={{
-                    width: 48,
-                    height: 48,
+                    width: '4.8rem',
+                    height: '4.8rem',
                     borderRadius: '50%',
                     overflow: 'hidden',
-                    flex: '0 0 48px',
+                    flex: '0 0 4.8rem',
                     background: 'rgba(255,255,255,0.95)',
                     display: 'flex',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    boxShadow: '0 1px 2px rgba(0,0,0,0.06)',
+                    boxShadow: '0 0.1rem 0.2rem rgba(0,0,0,0.06)',
                   }}
                 >
                   <img
@@ -479,13 +481,14 @@ const Money = () => {
                 <p
                   className={A.GreetText}
                   style={{
-                    margin: 3,
+                    margin: '0.3rem',
                     color: '#fff',
                     fontWeight: 500,
-                    fontSize: 18,
-                    lineHeight: '25px',
-                    letterSpacing: '-0.2px',
-                    paddingRight: 24,
+                    fontSize: '1.8rem',
+                    lineHeight: '2.5rem',
+                    letterSpacing: '-0.02rem',
+                    paddingRight: '2.4rem',
+                    whiteSpace: 'pre-line',
                   }}
                 >
                   {topCategory!.message}
@@ -889,9 +892,7 @@ const Money = () => {
                           <span className={`${A.DotBase} flex`}>
                             <img src={fixedCostImage} alt="fixed cost" />
                           </span>
-                          <span className="memo">
-                            {e.memo || e.categoryName || ''}
-                          </span>
+                          <span className="memo">{e.content || ''}</span>
                         </div>
 
                         <div className={A.ItemRowRight}>

--- a/src/pages/money/registration.tsx
+++ b/src/pages/money/registration.tsx
@@ -17,28 +17,6 @@ import type { RegistrationState } from '../../types/money/registration/registrat
 const CATEGORIES = ['배달/외식', '패션/쇼핑', '교통', '카페', '기타'];
 
 const BudgetRegister = () => {
-  useEffect(() => {
-    return () => {
-      if (
-        location.pathname === '/add-category' ||
-        location.pathname === '/budget-register'
-      )
-        return;
-      localStorage.removeItem('monthBudget');
-      localStorage.removeItem('categoryBudgets');
-      localStorage.removeItem('customCategories');
-      localStorage.removeItem('customCategoryBudgets');
-      localStorage.removeItem('routineCategories');
-      localStorage.removeItem('routineCategoryBudgets');
-      localStorage.removeItem('totalRoutineBudget');
-      localStorage.removeItem('year');
-      localStorage.removeItem('month');
-      localStorage.removeItem('budgetId');
-      localStorage.removeItem('routineId');
-      localStorage.removeItem('budgetInitialized');
-    };
-  }, [location.pathname]);
-
   const navigate = useNavigate();
 
   const { state } = useLocation() as {

--- a/src/pages/money/registration.tsx
+++ b/src/pages/money/registration.tsx
@@ -17,6 +17,28 @@ import type { RegistrationState } from '../../types/money/registration/registrat
 const CATEGORIES = ['배달/외식', '패션/쇼핑', '교통', '카페', '기타'];
 
 const BudgetRegister = () => {
+  useEffect(() => {
+    return () => {
+      if (
+        location.pathname === '/add-category' ||
+        location.pathname === '/budget-register'
+      )
+        return;
+      localStorage.removeItem('monthBudget');
+      localStorage.removeItem('categoryBudgets');
+      localStorage.removeItem('customCategories');
+      localStorage.removeItem('customCategoryBudgets');
+      localStorage.removeItem('routineCategories');
+      localStorage.removeItem('routineCategoryBudgets');
+      localStorage.removeItem('totalRoutineBudget');
+      localStorage.removeItem('year');
+      localStorage.removeItem('month');
+      localStorage.removeItem('budgetId');
+      localStorage.removeItem('routineId');
+      localStorage.removeItem('budgetInitialized');
+    };
+  }, [location.pathname]);
+
   const navigate = useNavigate();
 
   const { state } = useLocation() as {
@@ -79,27 +101,30 @@ const BudgetRegister = () => {
     if (!source) return;
     // console.log(source);
 
-    const {
-      totalBudget,
-      defaultCategoryBudgets = [],
-      customCategoryBudgets = [],
-      routineCategoryBudgets = [],
-    } = source;
+    const alreadyInit = localStorage.getItem('budgetInitialized');
 
-    const defaultArr = CATEGORIES.map(
-      (name) =>
-        defaultCategoryBudgets.find((c) => c.categoryName === name)?.amount ??
-        0,
-    );
+    if (!alreadyInit && (budgetId || routineId)) {
+      const {
+        totalBudget,
+        defaultCategoryBudgets = [],
+        customCategoryBudgets = [],
+        routineCategoryBudgets = [],
+      } = source;
 
-    const customNames = customCategoryBudgets?.map((c) => c.categoryName) ?? [];
-    const customAmounts = customCategoryBudgets?.map((c) => c.amount) ?? [];
+      const defaultArr = CATEGORIES.map(
+        (name) =>
+          defaultCategoryBudgets.find((c) => c.categoryName === name)?.amount ??
+          0,
+      );
 
-    const routineNames =
-      routineCategoryBudgets?.map((c) => c.categoryName) ?? [];
-    const routineAmounts = routineCategoryBudgets?.map((c) => c.amount) ?? [];
+      const customNames =
+        customCategoryBudgets?.map((c) => c.categoryName) ?? [];
+      const customAmounts = customCategoryBudgets?.map((c) => c.amount) ?? [];
 
-    if (!localStorage.getItem('monthBudget') || routineId) {
+      const routineNames =
+        routineCategoryBudgets?.map((c) => c.categoryName) ?? [];
+      const routineAmounts = routineCategoryBudgets?.map((c) => c.amount) ?? [];
+
       localStorage.setItem('monthBudget', String(totalBudget));
       localStorage.setItem('categoryBudgets', JSON.stringify(defaultArr));
       localStorage.setItem('customCategories', JSON.stringify(customNames));
@@ -120,7 +145,7 @@ const BudgetRegister = () => {
       setRoutineCategories(routineNames);
       setRoutineCatBudget(routineAmounts);
     }
-  }, [source, routineId]);
+  }, [source]);
 
   useEffect(() => {
     if (!budgetId) {
@@ -281,21 +306,13 @@ const BudgetRegister = () => {
           ? '소비 루틴 예산이 반영되었습니다.'
           : '한달 예산이 등록되었습니다.',
       );
-      localStorage.removeItem('monthBudget');
-      localStorage.removeItem('categoryBudgets');
-      localStorage.removeItem('customCategories');
-      localStorage.removeItem('customCategoryBudgets');
-      localStorage.removeItem('routineCategories');
-      localStorage.removeItem('routineCategoryBudgets');
-      localStorage.removeItem('year');
-      localStorage.removeItem('month');
-      localStorage.removeItem('budgetId');
-      localStorage.removeItem('routineId');
 
       navigate('/money', {
         replace: true,
         state: { total: data.result.totalBudget },
       });
+
+      localStorage.removeItem('budgetInitialized');
     };
 
     if (routineId) {

--- a/src/types/money/money/fixedCost.ts
+++ b/src/types/money/money/fixedCost.ts
@@ -3,6 +3,7 @@ export interface FixedConsumption {
   categoryName: string;
   amount: number;
   memo?: string;
+  content: string;
 }
 
 export interface FixedCostResult {


### PR DESCRIPTION
## 🚀 관련 이슈


## 🔑 작업 내용
- 타인의 소비루틴 예산 반영 시 get 안되는 오류 해결

## 📷 스크린샷


## 🌐 공유 사항 to 리뷰어


## 🚨 이슈 사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically clears temporary budget data when leaving budget-related pages.
  - Tips now support multi-line display for better readability.
  - Daily and fixed-cost items show detailed “content” instead of generic labels.

- Bug Fixes
  - Date picker opens reliably across devices and browsers with a safe fallback.

- Style
  - Refined spacing, sizing, and typography in money and fixed-cost views; improved tip rendering.

- Refactor
  - Streamlined budget registration initialization using server data for more consistent, one-time setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->